### PR TITLE
Create a new invoice

### DIFF
--- a/src/LexOfficeSharpApi.Test.NUnit/UnitTest.cs
+++ b/src/LexOfficeSharpApi.Test.NUnit/UnitTest.cs
@@ -1,7 +1,7 @@
 using AndreasReitberger.API.LexOffice;
+using AndreasReitberger.API.LexOffice.Enum;
 using AndreasReitberger.Core.Utilities;
 using Newtonsoft.Json;
-using System.Collections.ObjectModel;
 using System.Security;
 
 namespace LexOfficeSharpApi.Test.NUnit
@@ -48,7 +48,7 @@ namespace LexOfficeSharpApi.Test.NUnit
         }
 
         [Test]
-        public async Task TestGetInvoices()
+        public async Task TestGetInvoicesOpen()
         {
             try
             {
@@ -62,6 +62,91 @@ namespace LexOfficeSharpApi.Test.NUnit
             }
             catch (Exception ex) 
             {           
+                Assert.Fail(ex.Message);
+            }
+        }
+
+        [Test]
+        public async Task TestCreateInvoices()
+        {
+            try
+            {
+                SecureString token = SecureStringHelper.ConvertToSecureString(tokenString);
+                LexOfficeClient handler = new(token);
+
+                // Create a new invoice object
+                var invoice = new LexCreateInvoice()
+                {
+                    Address = new LexContactAddress()
+                    {
+                        Name = "Bike & Ride GmbH & Co. KG",
+                        Supplement = "Geb‰ude 10",
+                        Street = "Musterstraﬂe 42",
+                        City = "Freiburg",
+                        Zip = "79112",
+                        CountryCode = "DE",
+                    },
+                    LineItems = new List<LexQuotationItem>
+                    {
+                        new LexQuotationItem()
+                        {
+                            Type = "custom",
+                            Name = "test",
+                            Quantity = 1,
+                            UnitName = "test2",
+                            UnitPrice = new LexQuotationUnitPrice()
+                            {
+                                Currency = "EUR",
+                                NetAmount = 5,
+                                TaxRatePercentage = 0
+                            }
+                        }
+                    },
+                    TotalPrice = new LexQuotationTotalPrice()
+                    {
+                        Currency = "EUR",
+                        TotalNetAmount = 10,
+                        TotalGrossAmount = 10,
+                        TotalTaxAmount = 10
+                    },
+                    TaxConditions = new LexQuotationTaxConditions()
+                    {
+                        TaxType = "net"
+                    },
+                    ShippingConditions = new LexShippingConditions()
+                    {
+                        ShippingDate = DateTime.Now,
+                        ShippingEndDate = DateTime.Now,
+                        ShippingType = "none"
+                    },
+                    VoucherDate = DateTime.Now,
+                };
+
+                LexInvoiceResponse lexInvoiceResponse = await handler.AddInvoiceAsync(invoice, false);
+
+                Assert.That(lexInvoiceResponse != null);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+        }
+
+        [Test]
+        public async Task TestGetInvoicesDraft()
+        {
+            try
+            {
+                SecureString token = SecureStringHelper.ConvertToSecureString(tokenString);
+                LexOfficeClient handler = new(token);
+
+                List<VoucherListContent> invoicesList = await handler.GetInvoiceListAsync(LexVoucherStatus.draft);
+                List<LexQuotation> invoices = await handler.GetInvoicesAsync(invoicesList);
+
+                Assert.That(invoices != null && invoices.Count > 0);
+            }
+            catch (Exception ex)
+            {
                 Assert.Fail(ex.Message);
             }
         }

--- a/src/LexOfficeSharpApi/Enum/LexContactType.cs
+++ b/src/LexOfficeSharpApi/Enum/LexContactType.cs
@@ -1,4 +1,4 @@
-﻿namespace AndreasReitberger.API.LexOffice
+﻿namespace AndreasReitberger.API.LexOffice.Enum
 {
     public enum LexContactType
     {

--- a/src/LexOfficeSharpApi/Enum/LexVoucherStatus.cs
+++ b/src/LexOfficeSharpApi/Enum/LexVoucherStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace AndreasReitberger.API.LexOffice
+﻿namespace AndreasReitberger.API.LexOffice.Enum
 {
     public enum LexVoucherStatus
     {

--- a/src/LexOfficeSharpApi/Enum/LexVoucherType.cs
+++ b/src/LexOfficeSharpApi/Enum/LexVoucherType.cs
@@ -1,4 +1,4 @@
-﻿namespace AndreasReitberger.API.LexOffice
+﻿namespace AndreasReitberger.API.LexOffice.Enum
 {
     public enum LexVoucherType
     {

--- a/src/LexOfficeSharpApi/Model/Contact/LexContactAddress.cs
+++ b/src/LexOfficeSharpApi/Model/Contact/LexContactAddress.cs
@@ -6,6 +6,9 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
+        string name = string.Empty;
+
+        [ObservableProperty]
         string supplement = string.Empty;
 
         [ObservableProperty]

--- a/src/LexOfficeSharpApi/Model/Invoice/LexCreateInvoice.cs
+++ b/src/LexOfficeSharpApi/Model/Invoice/LexCreateInvoice.cs
@@ -1,0 +1,47 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.Generic;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    public partial class LexCreateInvoice : ObservableObject
+    {
+        #region Properties
+        [ObservableProperty]
+        DateTimeOffset voucherDate;
+
+        [ObservableProperty]
+        LexContactAddress? address;
+
+        [ObservableProperty]
+        List<LexQuotationItem> lineItems = [];
+
+        [ObservableProperty]
+        LexQuotationTotalPrice? totalPrice;
+
+        [ObservableProperty]
+        List<LexQuotationTaxAmount> taxAmounts = [];
+
+        [ObservableProperty]
+        LexQuotationTaxConditions taxConditions;
+
+        [ObservableProperty]
+        LexQuotationPaymentConditions? paymentConditions;
+        
+        [ObservableProperty]
+        LexShippingConditions shippingConditions;
+
+        [ObservableProperty]
+        string introduction = string.Empty;
+
+        [ObservableProperty]
+        string remark = string.Empty;
+
+        [ObservableProperty]
+        LexQuotationFiles? files;
+
+        [ObservableProperty]
+        string title = string.Empty;
+        #endregion
+    }
+}

--- a/src/LexOfficeSharpApi/Model/Invoice/LexInvoiceResponse.cs
+++ b/src/LexOfficeSharpApi/Model/Invoice/LexInvoiceResponse.cs
@@ -1,0 +1,25 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    public partial class LexInvoiceResponse : ObservableObject
+    {
+        #region Properties
+        [ObservableProperty]
+        Guid id;
+
+        [ObservableProperty]
+        string resourceUri = string.Empty;
+
+        [ObservableProperty]
+        DateTimeOffset createdDate;
+
+        [ObservableProperty]
+        DateTimeOffset updatedDate;
+
+        [ObservableProperty]
+        long version;
+        #endregion
+    }
+}

--- a/src/LexOfficeSharpApi/Model/Invoice/LexShippingConditions.cs
+++ b/src/LexOfficeSharpApi/Model/Invoice/LexShippingConditions.cs
@@ -1,0 +1,19 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    public partial class LexShippingConditions : ObservableObject
+    {
+        #region Properties
+        [ObservableProperty]
+        DateTimeOffset shippingDate;
+
+        [ObservableProperty]
+        DateTimeOffset shippingEndDate;
+
+        [ObservableProperty]
+        string shippingType;
+        #endregion
+    }
+}

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationItem.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationItem.cs
@@ -8,7 +8,7 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        Guid id;
+        Guid? id;
 
         [ObservableProperty]
         string type = string.Empty;


### PR DESCRIPTION
1. Added functionality to crate a new invoice.
2. Fixed a typo "GetInVoiceAsync" -> "GetInvoiceAsync"
3. Fixed Enum namespace.
4. Fixed an issue in 'InvoiceList' where invoices with only one page were not returned.
5. Added Tests.