### PR TITLE
Renamed `Enums` to start with a capital letter

### DIFF
--- a/src/LexOfficeSharpApi.Test.NUnit/UnitTest.cs
+++ b/src/LexOfficeSharpApi.Test.NUnit/UnitTest.cs
@@ -34,10 +34,10 @@ namespace LexOfficeSharpApi.Test.NUnit
             {
                 if (client is null) throw new NullReferenceException($"The client was null!");
 
-                List<VoucherListContent> invoicesList = await client.GetInvoiceListAsync(LexVoucherStatus.paid);
+                List<VoucherListContent> invoicesList = await client.GetInvoiceListAsync(LexVoucherStatus.Paid);
                 List<LexQuotation> invoices = await client.GetInvoicesAsync(invoicesList);
 
-                Assert.That(invoices != null && invoices.Count > 0);
+                Assert.That(invoices?.Count > 0);
             }
             catch (Exception ex)
             {
@@ -52,10 +52,10 @@ namespace LexOfficeSharpApi.Test.NUnit
             {
                 LexOfficeClient handler = new(tokenString);
 
-                List<VoucherListContent> invoicesList = await handler.GetInvoiceListAsync(LexVoucherStatus.open);
+                List<VoucherListContent> invoicesList = await handler.GetInvoiceListAsync(LexVoucherStatus.Open);
                 List<LexQuotation> invoices = await handler.GetInvoicesAsync(invoicesList);
 
-                Assert.That(invoices != null && invoices.Count > 0);
+                Assert.That(invoices?.Count > 0);
             }
             catch (Exception ex) 
             {           
@@ -85,7 +85,7 @@ namespace LexOfficeSharpApi.Test.NUnit
             {
                 LexOfficeClient handler = new(tokenString);
 
-                // Create a new invoice object
+                // Create a new Invoice object
                 LexCreateInvoice invoice = new()
                 {
                     Address = new LexContactAddress()
@@ -155,10 +155,10 @@ namespace LexOfficeSharpApi.Test.NUnit
             {
                 LexOfficeClient handler = new(tokenString);
 
-                List<VoucherListContent> invoicesList = await handler.GetInvoiceListAsync(LexVoucherStatus.draft);
+                List<VoucherListContent> invoicesList = await handler.GetInvoiceListAsync(LexVoucherStatus.Draft);
                 List<LexQuotation> invoices = await handler.GetInvoicesAsync(invoicesList);
 
-                Assert.That(invoices != null && invoices.Count > 0);
+                Assert.That(invoices?.Count > 0);
             }
             catch (Exception ex)
             {
@@ -172,7 +172,7 @@ namespace LexOfficeSharpApi.Test.NUnit
         {
             SecureString token = SecureStringHelper.ConvertToSecureString(tokenString);
             LexOfficeSharpApiHandler handler = new LexOfficeSharpApiHandler(token);
-            var quotesList = await handler.GetQuotationList(LexVoucherStatus.open);
+            var quotesList = await handler.GetQuotationList(LexVoucherStatus.Open);
             var quotes = await handler.GetQuotations(quotesList);
 
             Assert.IsTrue(quotes != null && quotes.Count > 0);

--- a/src/LexOfficeSharpApi/Enum/LexQuotationTaxType.cs
+++ b/src/LexOfficeSharpApi/Enum/LexQuotationTaxType.cs
@@ -1,0 +1,9 @@
+﻿namespace AndreasReitberger.API.LexOffice.Enum
+{
+    public enum LexQuotationTaxType
+    {
+        Net,
+        Gross,
+        Vatfree,
+    }
+}

--- a/src/LexOfficeSharpApi/Enum/LexVoucherStatus.cs
+++ b/src/LexOfficeSharpApi/Enum/LexVoucherStatus.cs
@@ -2,13 +2,13 @@
 {
     public enum LexVoucherStatus
     {
-        draft,
-        open,
-        overdue,
-        paid,
-        paidoff,
-        voided,
-        accepted,
-        rejected,
+        Draft,
+        Open,
+        Overdue,
+        Paid,
+        Paidoff,
+        Voided,
+        Accepted,
+        Rejected,
     }
 }

--- a/src/LexOfficeSharpApi/Enum/LexVoucherType.cs
+++ b/src/LexOfficeSharpApi/Enum/LexVoucherType.cs
@@ -2,13 +2,13 @@
 {
     public enum LexVoucherType
     {
-        salesinvoice,
-        salescreditnote,
-        purchaseinvoice,
-        purchasecreditnote,
-        invoice,
-        creditnote,
-        orderconfirmation,
-        quotation,
+        SalesInvoice,
+        SalesCreditnote,
+        PurchaseInvoice,
+        PurchaseCreditnote,
+        Invoice,
+        CreditNote,
+        OrderConfirmation,
+        Quotation,
     }
 }

--- a/src/LexOfficeSharpApi/LexOfficeClient.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.cs
@@ -320,9 +320,7 @@ namespace AndreasReitberger.API.LexOffice
         public async Task<List<LexContact>> GetContactsAsync(LexContactType type, int page = 0, int size = 25, int coolDown = 20)
         {
             List<LexContact> result = [];
-            string cmd = string.Format("contacts{0}",
-                type == LexContactType.Customer ? "?customer=true" : "?vendor=true"              
-                );
+            string cmd = $"contacts?{(type == LexContactType.Customer ? "customer" : "vendor")}=true";
             cmd += $"&page={page}&size={size}";
 
             string? jsonString = await BaseApiCallAsync(cmd, Method.Get) ?? string.Empty;
@@ -355,9 +353,8 @@ namespace AndreasReitberger.API.LexOffice
         public async Task<List<LexQuotationPaymentConditions>> GetPaymentConditionsAsync()
         {
             List<LexQuotationPaymentConditions> result = [];
-
             string? jsonString = await BaseApiCallAsync($"payment-conditions", Method.Get) ?? string.Empty;
-            result = JsonConvert.DeserializeObject<List<LexQuotationPaymentConditions>>(jsonString);
+            result = JsonConvert.DeserializeObject<List<LexQuotationPaymentConditions>>(jsonString) ?? [];
             return result;
         }
         #endregion
@@ -366,12 +363,10 @@ namespace AndreasReitberger.API.LexOffice
         public async Task<List<VoucherListContent>> GetInvoiceListAsync(LexVoucherStatus status, bool archived = false, int page = 0, int size = 25)
         {
             List<VoucherListContent> result = [];
-            string type = LexVoucherType.invoice.ToString();
-            string cmd = string.Format("voucherlist?{0}&{1}&{2}",
-                $"voucherType={type}",
-                $"voucherStatus={status}",
-                $"archived={archived}"
-                );
+            string cmd = $"voucherlist?voucherType={LexVoucherType.Invoice.ToString().ToLower()}" +
+                $"&voucherStatus={status.ToString().ToLower()}" +
+                $"&archived={archived}"
+                ;
             cmd += $"&page={page}&size={size}";
 
             string? jsonString = await BaseApiCallAsync(cmd, Method.Get) ?? string.Empty;
@@ -411,15 +406,15 @@ namespace AndreasReitberger.API.LexOffice
         public async Task<LexQuotation?> GetInvoiceAsync(Guid id)
         {
             string? jsonString = await BaseApiCallAsync($"invoices/{id}", Method.Get) ?? string.Empty;
-            LexQuotation? contact = JsonConvert.DeserializeObject<LexQuotation>(jsonString);
-            return contact;
+            LexQuotation? response = JsonConvert.DeserializeObject<LexQuotation>(jsonString);
+            return response;
         }
 
         public async Task<LexInvoiceResponse?> AddInvoiceAsync(LexCreateInvoice lexQuotation, bool isFinalized = false)
         {
             string? jsonString = await BaseApiCallAsync($"invoices?finalize={isFinalized}", Method.Post, JsonConvert.SerializeObject(lexQuotation, jsonSerializerSettings)) ?? string.Empty;
-            LexInvoiceResponse? contact = JsonConvert.DeserializeObject<LexInvoiceResponse>(jsonString);
-            return contact;
+            LexInvoiceResponse? response = JsonConvert.DeserializeObject<LexInvoiceResponse>(jsonString);
+            return response;
         }
         #endregion
 
@@ -427,12 +422,10 @@ namespace AndreasReitberger.API.LexOffice
         public async Task<List<VoucherListContent>> GetQuotationListAsync(LexVoucherStatus status, bool archived = false, int page = 0, int size = 25)
         {
             List<VoucherListContent> result = [];
-            string type = LexVoucherType.quotation.ToString();
-            string cmd = string.Format("voucherlist?{0}&{1}&{2}",
-                $"voucherType={type}",
-                $"voucherStatus={status}",
-                $"archived={archived}"
-                );
+            string cmd = $"voucherlist?voucherType={LexVoucherType.Quotation.ToString().ToLower()}" +
+                $"&voucherStatus={status.ToString().ToLower()}" +
+                $"&archived={archived}"
+                ;
             cmd += $"&page={page}&size={size}";
 
             string? jsonString = await BaseApiCallAsync(cmd, Method.Get) ?? string.Empty;
@@ -472,8 +465,8 @@ namespace AndreasReitberger.API.LexOffice
         public async Task<LexQuotation?> GetQuotationAsync(Guid id)
         {
             string? jsonString = await BaseApiCallAsync($"quotations/{id}", Method.Get) ?? string.Empty;
-            LexQuotation? contact = JsonConvert.DeserializeObject<LexQuotation>(jsonString);
-            return contact;
+            LexQuotation? response = JsonConvert.DeserializeObject<LexQuotation>(jsonString);
+            return response;
         }
         #endregion
 

--- a/src/LexOfficeSharpApi/Model/Invoice/LexCreateInvoice.cs
+++ b/src/LexOfficeSharpApi/Model/Invoice/LexCreateInvoice.cs
@@ -8,6 +8,9 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
+        bool archived;
+
+        [ObservableProperty]
         DateTimeOffset voucherDate;
 
         [ObservableProperty]

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationTaxConditions.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationTaxConditions.cs
@@ -1,4 +1,6 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using AndreasReitberger.API.LexOffice.Enum;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Newtonsoft.Json;
 
 namespace AndreasReitberger.API.LexOffice
 {
@@ -7,7 +9,11 @@ namespace AndreasReitberger.API.LexOffice
         #region Properties
 
         [ObservableProperty]
-        string taxType = string.Empty;
+        [NotifyPropertyChangedFor(nameof(TaxTypeString))]
+        LexQuotationTaxType taxType;
+
+        [JsonIgnore]
+        public string TaxTypeString => $"{TaxType}";
 
         #endregion
     }


### PR DESCRIPTION
This PR renames all enums to start with a capital letter. Some url properties however must be lower cased, so the function calls have been updated to use `ToLower`.

Fixed #35