### PR TITLE
Add invoice correction

### DIFF
--- a/src/LexOfficeSharpApi.Test.NUnit/UnitTest.cs
+++ b/src/LexOfficeSharpApi.Test.NUnit/UnitTest.cs
@@ -158,8 +158,50 @@ namespace LexOfficeSharpApi.Test.NUnit
             }
         }
 
+        [Test]
+        public async Task TestCreateCreditNoteDraft()
+        {
+            try
+            {
+                LexOfficeClient handler = new(tokenString);
+
+                List<VoucherListContent> invoicesList = await handler.GetInvoiceListAsync(LexVoucherStatus.Open);
+
+                List<LexDocumentRespone> invoices = await handler.GetInvoicesAsync(invoicesList);
+                var invoice = invoices.FirstOrDefault();
+
+                var voucherNumber = invoice.VoucherNumber;
+
+                invoice.Title = "Rechnungskorrektur";
+                invoice.Introduction = $"Rechnungskorrektur zur Rechnung {voucherNumber}";
+
+                invoice.LineItems.Add(
+                    new LexQuotationItem()
+                    {
+                        Type = "custom",
+                        Name = "Energieriegel Testpaket",
+                        Quantity = 0.1m,
+                        UnitName = "Stück",
+                        UnitPrice = new LexQuotationUnitPrice()
+                        {
+                            Currency = "EUR",
+                            NetAmount = -150,
+                            TaxRatePercentage = 0
+                        }
+                    }
+                );
+
+                var rs = await handler.AddCreditNoteAsync(invoice, true);
+
+                Assert.That(rs != null);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+        }
         #endregion
-          
+
         #region Payments
         [Test]
         public async Task TestGetPayments()

--- a/src/LexOfficeSharpApi/LexOfficeClient.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.cs
@@ -496,7 +496,7 @@ namespace AndreasReitberger.API.LexOffice
         #endregion
 
         #region Invoices
-        public async Task<List<VoucherListContent>> GetInvoiceListAsync(LexVoucherStatus status, bool archived = false, int page = 0, int size = 25, int pages = -1, int cooldown = 500)
+        public async Task<List<VoucherListContent>> GetInvoiceListAsync(LexVoucherStatus status, bool archived = false, int page = 0, int size = 25, int pages = -1, int cooldown = 0)
         {
             List<VoucherListContent> result = [];
             string cmd = $"voucherlist?voucherType={LexVoucherType.Invoice.ToString().ToLower()}" +
@@ -525,7 +525,7 @@ namespace AndreasReitberger.API.LexOffice
             return result;
         }
 
-        public async Task<List<LexDocumentRespone>> GetInvoicesAsync(List<Guid> ids, int cooldown = 500)
+        public async Task<List<LexDocumentRespone>> GetInvoicesAsync(List<Guid> ids, int cooldown = 0)
         {
             List<LexDocumentRespone> result = [];
             foreach (Guid id in ids)

--- a/src/LexOfficeSharpApi/LexOfficeClient.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.cs
@@ -439,6 +439,14 @@ namespace AndreasReitberger.API.LexOffice
             LexDocumentRespone? respone = JsonConvert.DeserializeObject<LexDocumentRespone>(jsonString);
             return respone;
         }
+
+        public async Task<LexResponseDefault?> AddCreditNoteAsync(LexDocumentRespone lexQuotation, bool isFinalized = false)
+        {
+            var body = JsonConvert.SerializeObject(lexQuotation, JsonSerializerSettings);
+            string? jsonString = await BaseApiCallAsync<string>($"credit-notes/?finalize={isFinalized}", Method.Post, body) ?? string.Empty;
+            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
+            return response;
+        }
         #endregion
 
         #region Conditions
@@ -481,7 +489,7 @@ namespace AndreasReitberger.API.LexOffice
             return result;
         }
 
-        public async Task<List<LexDocumentRespone>> GetInvoicesAsync(List<Guid> ids, int cooldown = 50)
+        public async Task<List<LexDocumentRespone>> GetInvoicesAsync(List<Guid> ids, int cooldown = 500)
         {
             List<LexDocumentRespone> result = [];
             foreach (Guid id in ids)

--- a/src/LexOfficeSharpApi/LexOfficeClient.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.cs
@@ -461,7 +461,7 @@ namespace AndreasReitberger.API.LexOffice
         #endregion
 
         #region Invoices
-        public async Task<List<VoucherListContent>> GetInvoiceListAsync(LexVoucherStatus status, bool archived = false, int page = 0, int size = 25, int pages = -1, int cooldown = 250)
+        public async Task<List<VoucherListContent>> GetInvoiceListAsync(LexVoucherStatus status, bool archived = false, int page = 0, int size = 25, int pages = -1, int cooldown = 500)
         {
             List<VoucherListContent> result = [];
             string cmd = $"voucherlist?voucherType={LexVoucherType.Invoice.ToString().ToLower()}" +

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationItem.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationItem.cs
@@ -23,7 +23,7 @@ namespace AndreasReitberger.API.LexOffice
         string description = string.Empty;
 
         [ObservableProperty]
-        long quantity;
+        decimal quantity;
 
         [ObservableProperty]
         string unitName = string.Empty;


### PR DESCRIPTION
- Added feature to create invoice corrections.
- Had to increase "cooldown" otherwise "Request failed with status code 429 (TooManyRequests). Response content: {"message": "Rate limit exceeded"}"
---

This is always null when I run the tests (using windows), maybe you can double check it.

```
        private readonly string tokenString = SecretAppSettingReader.ReadSection<SecretAppSetting>("TestSetup").ApiKey ?? "";
```