### PR TITLE
Show more details on Exception

### DIFF
--- a/src/LexOfficeSharpApi/LexOfficeClient.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.cs
@@ -220,7 +220,7 @@ namespace AndreasReitberger.API.LexOffice
 #endif
             RestClientOptions options = new($"{AppBaseUrl}{ApiVersion}/")
             {
-                ThrowOnAnyError = true,
+                ThrowOnAnyError = false,
                 Timeout = TimeSpan.FromSeconds(DefaultTimeout / 1000),
             };
             if (EnableProxy && !string.IsNullOrEmpty(ProxyAddress))


### PR DESCRIPTION
This update enhances error handling for requests that fail with a "Status 406" error. Previously, when such requests failed, the ExecuteAsync method would throw a generic exception, obscuring valuable details about the failure that were present in the response body.

With this fix, the response content is included in the exception message, providing more context about what went wrong. Instead of a generic exception, the following logic is now executed:

```
else
{
    string errorMessage = $"Request failed with status code {(int)response.StatusCode} ({response.StatusCode}).";

    if (!string.IsNullOrEmpty(response.Content))
    {
        errorMessage += $" Response content: {response.Content}";
    }

    throw new HttpRequestException(errorMessage);
}
```

This ensures that the exception includes both the HTTP status code and the relevant details from the response body, enabling easier debugging and resolution.