### PR TITLE
Switched to `RestApiClient`

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>1.0.8</Version>
-        <!--<PackageIcon>logo_128.png</PackageIcon>-->
+        <Version>1.0.8-preview</Version>
+        <PackageIcon>ar_128.png</PackageIcon>
         <NeutralLanguage>en</NeutralLanguage>
         <PackageProjectUrl>https://github.com/AndreasReitberger/LexOfficeClientSharp</PackageProjectUrl>
         <RepositoryUrl>https://github.com/AndreasReitberger/LexOfficeClientSharp</RepositoryUrl>
@@ -9,7 +9,7 @@
         <PackageReleaseNotes>Check GitHub releases for changelog.</PackageReleaseNotes>
         <Authors>Andreas Reitberger</Authors>
         <Copyright>Andreas Reitberger</Copyright>
-        <LangVersion>12</LangVersion>
+        <LangVersion>preview</LangVersion>
         <PublishReadyToRun>false</PublishReadyToRun>
 		<Nullable>enable</Nullable>
 

--- a/src/LexOfficeSharpApi.Test.NUnit/LexOfficeSharpApi.Test.NUnit.csproj
+++ b/src/LexOfficeSharpApi.Test.NUnit/LexOfficeSharpApi.Test.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/LexOfficeSharpApi.Test.NUnit/UnitTest.cs
+++ b/src/LexOfficeSharpApi.Test.NUnit/UnitTest.cs
@@ -209,23 +209,23 @@ namespace LexOfficeSharpApi.Test.NUnit
                 LexOfficeClient handler = new(tokenString);
 
                 // Cleanup available event subscriptions
-                List<LexResponseDefault> allSubscriptions = await handler.GetAllEventSubscriptionsAsync();
-                foreach (var subscriptions in allSubscriptions)
+                List<LexResponseDefault>? allSubscriptions = await handler.GetAllEventSubscriptionsAsync();
+                foreach (LexResponseDefault subscriptions in allSubscriptions)
                 {
                     await handler.DeleteEventSubscriptionAsync(subscriptions.SubscriptionId);
                 }
 
                 // Create event subscription
-                LexResponseDefault newSubscription = await handler.AddEventSubscriptionAsync(new LexResponseDefault
+                LexResponseDefault? newSubscription = await handler.AddEventSubscriptionAsync(new LexResponseDefault
                 {
                     EventType = EventTypes.PaymentChanged,
                     CallbackUrl = "https://webhook.site/11dac08c-7a64-4467-aae9-8ec5dd1f3338"
                 });
 
-                LexResponseDefault subscription = await handler.GetEventSubscriptionAsync(newSubscription.Id);
+                LexResponseDefault? subscription = await handler.GetEventSubscriptionAsync(newSubscription.Id);
 
                 Assert.That(newSubscription != null);
-                Assert.That(newSubscription.Id != subscription.Id);
+                Assert.That(newSubscription?.Id != subscription?.Id);
                 Assert.That(newSubscription.EventType != subscription.EventType);
             }
             catch (Exception ex)
@@ -301,8 +301,9 @@ namespace LexOfficeSharpApi.Test.NUnit
 
                 Guid documentId = files.DocumentFileId;// Guid.Parse("YOUR_FILE_ID");
                 byte[] file = await handler.GetFileAsync(documentId);
-
                 Assert.That(file is not null);
+
+                await File.WriteAllBytesAsync($"invoice.pdf", file);
             }
             catch (Exception ex)
             {
@@ -400,7 +401,6 @@ namespace LexOfficeSharpApi.Test.NUnit
                 Guid id = list.FirstOrDefault().Id;
                 var contact = await handler.GetContactAsync(id);
                 Assert.That(contact is not null);
-
             }
             catch (Exception ex)
             {

--- a/src/LexOfficeSharpApi.Test.NUnit/UnitTest.cs
+++ b/src/LexOfficeSharpApi.Test.NUnit/UnitTest.cs
@@ -436,5 +436,13 @@ namespace LexOfficeSharpApi.Test.NUnit
         }
 
         #endregion
+
+        #region Cleanup
+        [TearDown]
+        public void BaseTearDown()
+        {
+            client?.Dispose();
+        }
+        #endregion
     }
 }

--- a/src/LexOfficeSharpApi/LexOfficeClient.Conditions.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Conditions.cs
@@ -1,0 +1,33 @@
+﻿#if !NETFRAMEWORK
+using AndreasReitberger.API.REST;
+#else
+using CommunityToolkit.Mvvm.ComponentModel;
+#endif
+using Newtonsoft.Json;
+using RestSharp;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
+    {
+        #region Conditions
+
+        public async Task<List<LexQuotationPaymentConditions>> GetPaymentConditionsAsync()
+        {
+            List<LexQuotationPaymentConditions> result = [];
+            string? jsonString = await BaseApiCallAsync<string>($"payment-conditions", Method.Get) ?? string.Empty;
+            result = JsonConvert.DeserializeObject<List<LexQuotationPaymentConditions>>(jsonString) ?? [];
+            return result;
+        }
+        #endregion
+
+    }
+}

--- a/src/LexOfficeSharpApi/LexOfficeClient.Conditions.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Conditions.cs
@@ -1,10 +1,13 @@
 ﻿#if !NETFRAMEWORK
 using AndreasReitberger.API.REST;
+using AndreasReitberger.API.REST.Interfaces;
+
 #else
 using CommunityToolkit.Mvvm.ComponentModel;
 #endif
 using Newtonsoft.Json;
 using RestSharp;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -20,6 +23,7 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Conditions
 
+#if NETFRAMEWORK
         public async Task<List<LexQuotationPaymentConditions>> GetPaymentConditionsAsync()
         {
             List<LexQuotationPaymentConditions> result = [];
@@ -27,6 +31,35 @@ namespace AndreasReitberger.API.LexOffice
             result = JsonConvert.DeserializeObject<List<LexQuotationPaymentConditions>>(jsonString) ?? [];
             return result;
         }
+#else
+
+        public async Task<List<LexQuotationPaymentConditions>> GetPaymentConditionsAsync()
+        {
+            IRestApiRequestRespone? result = null;
+            List<LexQuotationPaymentConditions> resultObject = [];
+            try
+            {
+                string targetUri = $"payment-conditions";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Get,
+                       command: "",
+                       jsonObject: null,
+                       authHeaders: AuthHeaders,
+                       urlSegments: null,
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = [.. GetObjectFromJson<List<LexQuotationPaymentConditions>>(result?.Result, base.NewtonsoftJsonSerializerSettings)];
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+#endif
         #endregion
 
     }

--- a/src/LexOfficeSharpApi/LexOfficeClient.Conditions.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Conditions.cs
@@ -50,7 +50,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = [.. GetObjectFromJson<List<LexQuotationPaymentConditions>>(result?.Result, base.NewtonsoftJsonSerializerSettings)];
+                resultObject = [.. GetObjectFromJson<List<LexQuotationPaymentConditions>>(result?.Result, NewtonsoftJsonSerializerSettings)];
                 return resultObject;
             }
             catch (Exception exc)

--- a/src/LexOfficeSharpApi/LexOfficeClient.Contacts.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Contacts.cs
@@ -1,0 +1,116 @@
+﻿using AndreasReitberger.API.LexOffice.Enum;
+#if !NETFRAMEWORK
+using AndreasReitberger.API.REST;
+using AndreasReitberger.API.REST.Events;
+using AndreasReitberger.API.REST.Interfaces;
+#else
+using CommunityToolkit.Mvvm.ComponentModel;
+#endif
+using Newtonsoft.Json;
+using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
+    {
+
+        #region Contacts
+        public async Task<List<LexContact>> GetContactsAsync(LexContactType type, int page = 0, int size = 25, int pages = -1, int cooldown = 0)
+        {
+            List<LexContact> result = [];
+            string cmd = $"contacts?{(type == LexContactType.Customer ? "customer" : "vendor")}=true";
+            cmd += $"&page={page}&size={size}";
+
+            string? jsonString = await BaseApiCallAsync<string>(cmd, Method.Get) ?? string.Empty;
+            LexContactsList? list = JsonConvert.DeserializeObject<LexContactsList>(jsonString);
+            if (list != null)
+            {
+                if (list.TotalPages > 1 && page < list.TotalPages && (pages <= 0 || (pages - 1 > page && pages > 1)))
+                {
+                    result = new List<LexContact>(list.Content);
+                    if (MinimumCooldown > 0 && cooldown > 0)
+                        await Task.Delay(cooldown < MinimumCooldown ? MinimumCooldown : cooldown);
+                    page++;
+                    List<LexContact> append = await GetContactsAsync(type, page, size, pages, cooldown);
+                    result = new List<LexContact>(result.Concat(append));
+                    return result;
+                }
+                else
+                    result = new List<LexContact>(list.Content);
+            }
+            return result;
+        }
+
+        public async Task<LexContact?> GetContactAsync(Guid id)
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"contacts/{id}", Method.Get) ?? string.Empty;
+            LexContact? contact = JsonConvert.DeserializeObject<LexContact>(jsonString);
+            return contact;
+        }
+#if !NETFRAMEWORK
+        public async Task<LexContact?> GetContactNewAsync(Guid id)
+        {
+            IRestApiRequestRespone? result = null;
+            LexContact? resultObject = null;
+            try
+            {
+                string targetUri = $"contacts/{id}";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Get,
+                       command: "",
+                       jsonObject: null,
+                       authHeaders: AuthHeaders,
+                       urlSegments: null,
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = GetObjectFromJson<LexContact>(result?.Result, NewtonsoftJsonSerializerSettings);
+                return resultObject;
+            }
+            catch (JsonException jecx)
+            {
+                OnError(new JsonConvertEventArgs()
+                {
+                    Exception = jecx,
+                    OriginalString = result?.Result,
+                    TargetType = nameof(GetContactAsync),
+                    Message = jecx.Message,
+                });
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+#endif
+        public async Task<LexResponseDefault?> AddContactAsync(LexContact lexContact)
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"contacts", Method.Post, JsonConvert.SerializeObject(lexContact, JsonSerializerSettings)) ?? string.Empty;
+            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
+            return response;
+        }
+
+        public async Task<LexResponseDefault?> UpdateContactAsync(Guid contactId, LexContact lexContact)
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"contacts/{contactId}", Method.Post, JsonConvert.SerializeObject(lexContact, JsonSerializerSettings)) ?? string.Empty;
+            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
+            return response;
+        }
+
+#endregion
+
+    }
+}

--- a/src/LexOfficeSharpApi/LexOfficeClient.Contacts.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Contacts.cs
@@ -96,7 +96,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                LexContactsList? list = GetObjectFromJson<LexContactsList>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                LexContactsList? list = GetObjectFromJson<LexContactsList>(result?.Result, NewtonsoftJsonSerializerSettings);
                 if (list is not null)
                 {
                     if (list.TotalPages > 1 && page < list.TotalPages && (pages <= 0 || (pages - 1 > page && pages > 1)))
@@ -138,7 +138,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexContact>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexContact>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)
@@ -166,7 +166,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)
@@ -193,7 +193,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)

--- a/src/LexOfficeSharpApi/LexOfficeClient.Countries.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Countries.cs
@@ -1,0 +1,32 @@
+﻿#if !NETFRAMEWORK
+using AndreasReitberger.API.REST;
+#else
+using CommunityToolkit.Mvvm.ComponentModel;
+#endif
+using Newtonsoft.Json;
+using RestSharp;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
+    {
+        #region Countries
+
+        public async Task<List<LexCountry>> GetCountriesAsync()
+        {
+            List<LexCountry> result = [];
+            string? jsonString = await BaseApiCallAsync<string>("countries", Method.Get) ?? string.Empty;
+            result = JsonConvert.DeserializeObject<List<LexCountry>>(jsonString) ?? [];
+            return result;
+        }
+        #endregion
+    }
+}

--- a/src/LexOfficeSharpApi/LexOfficeClient.Countries.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Countries.cs
@@ -51,7 +51,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = [.. GetObjectFromJson<List<LexCountry>>(result?.Result, base.NewtonsoftJsonSerializerSettings)];
+                resultObject = [.. GetObjectFromJson<List<LexCountry>>(result?.Result, NewtonsoftJsonSerializerSettings)];
                 return resultObject;
             }
             catch (Exception exc)

--- a/src/LexOfficeSharpApi/LexOfficeClient.Countries.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Countries.cs
@@ -1,11 +1,15 @@
 ﻿#if !NETFRAMEWORK
 using AndreasReitberger.API.REST;
+using AndreasReitberger.API.REST.Interfaces;
+
 #else
 using CommunityToolkit.Mvvm.ComponentModel;
 #endif
 using Newtonsoft.Json;
 using RestSharp;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace AndreasReitberger.API.LexOffice
@@ -20,6 +24,7 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Countries
 
+#if NETFRAMEWORK
         public async Task<List<LexCountry>> GetCountriesAsync()
         {
             List<LexCountry> result = [];
@@ -27,6 +32,35 @@ namespace AndreasReitberger.API.LexOffice
             result = JsonConvert.DeserializeObject<List<LexCountry>>(jsonString) ?? [];
             return result;
         }
+#else
+
+        public async Task<List<LexCountry>> GetCountriesAsync()
+        {
+            IRestApiRequestRespone? result = null;
+            List<LexCountry> resultObject = [];
+            try
+            {
+                string targetUri = $"countries";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Get,
+                       command: "",
+                       jsonObject: null,
+                       authHeaders: AuthHeaders,
+                       urlSegments: null,
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = [.. GetObjectFromJson<List<LexCountry>>(result?.Result, base.NewtonsoftJsonSerializerSettings)];
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+#endif
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/LexOfficeClient.CreditNotes.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.CreditNotes.cs
@@ -66,7 +66,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = [.. GetObjectFromJson<List<LexDocumentResponse>>(result?.Result, base.NewtonsoftJsonSerializerSettings)];
+                resultObject = [.. GetObjectFromJson<List<LexDocumentResponse>>(result?.Result, NewtonsoftJsonSerializerSettings)];
                 return resultObject;
             }
             catch (Exception exc)
@@ -93,7 +93,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexDocumentResponse>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexDocumentResponse>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)
@@ -124,7 +124,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)

--- a/src/LexOfficeSharpApi/LexOfficeClient.CreditNotes.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.CreditNotes.cs
@@ -1,5 +1,7 @@
 ﻿#if !NETFRAMEWORK
 using AndreasReitberger.API.REST;
+using AndreasReitberger.API.REST.Interfaces;
+
 #else
 using CommunityToolkit.Mvvm.ComponentModel;
 #endif
@@ -22,6 +24,7 @@ namespace AndreasReitberger.API.LexOffice
 
         #region Credit Notes
 
+#if NETFRAMEWORK
         public async Task<List<LexDocumentResponse>> GetCreditNotesAsync()
         {
             List<LexDocumentResponse> result = [];
@@ -39,11 +42,98 @@ namespace AndreasReitberger.API.LexOffice
 
         public async Task<LexResponseDefault?> AddCreditNoteAsync(LexDocumentResponse lexQuotation, bool isFinalized = false)
         {
-            var body = JsonConvert.SerializeObject(lexQuotation, JsonSerializerSettings);
+            var body = JsonConvert.SerializeObject(lexQuotation, NewtonsoftJsonSerializerSettings);
             string? jsonString = await BaseApiCallAsync<string>($"credit-notes/?finalize={isFinalized}", Method.Post, body) ?? string.Empty;
             LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
             return response;
         }
+#else
+
+        public async Task<List<LexDocumentResponse>> GetCreditNotesAsync()
+        {
+            IRestApiRequestRespone? result = null;
+            List<LexDocumentResponse> resultObject = [];
+            try
+            {
+                string targetUri = $"credit-notes";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Get,
+                       command: "",
+                       jsonObject: null,
+                       authHeaders: AuthHeaders,
+                       urlSegments: null,
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = [.. GetObjectFromJson<List<LexDocumentResponse>>(result?.Result, base.NewtonsoftJsonSerializerSettings)];
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+
+        public async Task<LexDocumentResponse?> GetCreditNoteAsync(Guid id)
+        {
+            IRestApiRequestRespone? result = null;
+            LexDocumentResponse? resultObject = null;
+            try
+            {
+                string targetUri = $"credit-notes/{id}";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Get,
+                       command: "",
+                       jsonObject: null,
+                       authHeaders: AuthHeaders,
+                       urlSegments: null,
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = GetObjectFromJson<LexDocumentResponse>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+
+        public async Task<LexResponseDefault?> AddCreditNoteAsync(LexDocumentResponse lexQuotation, bool isFinalized = false)
+        {
+            IRestApiRequestRespone? result = null;
+            LexResponseDefault? resultObject = null;
+            try
+            {
+                string json = JsonConvert.SerializeObject(lexQuotation, NewtonsoftJsonSerializerSettings);
+                string targetUri = $"credit-notes";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Post,
+                       command: "",
+                       jsonObject: json,
+                       authHeaders: AuthHeaders,
+                       urlSegments: new()
+                       {
+                           { "finalize", $"{isFinalized}"   }
+                       },
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+#endif
         #endregion
 
     }

--- a/src/LexOfficeSharpApi/LexOfficeClient.CreditNotes.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.CreditNotes.cs
@@ -1,0 +1,50 @@
+﻿#if !NETFRAMEWORK
+using AndreasReitberger.API.REST;
+#else
+using CommunityToolkit.Mvvm.ComponentModel;
+#endif
+using Newtonsoft.Json;
+using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
+    {
+
+        #region Credit Notes
+
+        public async Task<List<LexDocumentResponse>> GetCreditNotesAsync()
+        {
+            List<LexDocumentResponse> result = [];
+            string? jsonString = await BaseApiCallAsync<string>("credit-notes", Method.Get) ?? string.Empty;
+            result = JsonConvert.DeserializeObject<List<LexDocumentResponse>>(jsonString) ?? [];
+            return result;
+        }
+
+        public async Task<LexDocumentResponse?> GetCreditNoteAsync(Guid id)
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"credit-notes/{id}", Method.Get) ?? string.Empty;
+            LexDocumentResponse? respone = JsonConvert.DeserializeObject<LexDocumentResponse>(jsonString);
+            return respone;
+        }
+
+        public async Task<LexResponseDefault?> AddCreditNoteAsync(LexDocumentResponse lexQuotation, bool isFinalized = false)
+        {
+            var body = JsonConvert.SerializeObject(lexQuotation, JsonSerializerSettings);
+            string? jsonString = await BaseApiCallAsync<string>($"credit-notes/?finalize={isFinalized}", Method.Post, body) ?? string.Empty;
+            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
+            return response;
+        }
+        #endregion
+
+    }
+}

--- a/src/LexOfficeSharpApi/LexOfficeClient.Documents.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Documents.cs
@@ -1,0 +1,38 @@
+﻿using AndreasReitberger.API.LexOffice.Enum;
+#if !NETFRAMEWORK
+using AndreasReitberger.API.REST;
+#else
+using CommunityToolkit.Mvvm.ComponentModel;
+#endif
+using Newtonsoft.Json;
+using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
+    {
+        #region Documents
+
+        public async Task<LexQuotationFiles?> RenderDocumentAsync(Guid invoiceId)
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"invoices/{invoiceId}/document", Method.Get);
+            if (jsonString is null) return null;
+            LexQuotationFiles? response = JsonConvert.DeserializeObject<LexQuotationFiles>(jsonString);
+            return response;
+        }
+
+        public Task<byte[]?> GetFileAsync(Guid id) => BaseApiCallAsync<byte[]>($"files/{id}", Method.Get);
+
+        #endregion
+    }
+}

--- a/src/LexOfficeSharpApi/LexOfficeClient.Documents.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Documents.cs
@@ -56,7 +56,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexQuotationFiles>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexQuotationFiles>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)

--- a/src/LexOfficeSharpApi/LexOfficeClient.ErrorHandling.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.ErrorHandling.cs
@@ -1,0 +1,34 @@
+﻿#if !NETFRAMEWORK
+using System;
+using AndreasReitberger.API.REST;
+using AndreasReitberger.API.REST.Interfaces;
+#else
+using CommunityToolkit.Mvvm.ComponentModel;
+#endif
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
+    {
+        #region Error Handling
+
+#if !NETFRAMEWORK
+        public static void ThrowOnError(IRestApiRequestRespone? respone, string methodName)
+        {
+            throw new Exception($"Error in '{methodName}' => Result: {respone?.Result} " +
+                $"\n- StatusCode: {respone?.EventArgs?.Status}" +
+                $"\n- Error: {respone?.EventArgs?.Message}" +
+                $"\n- Uri: {respone?.EventArgs?.Uri}",
+                respone?.EventArgs?.Exception
+                );
+        }
+#endif
+        #endregion
+    }
+}

--- a/src/LexOfficeSharpApi/LexOfficeClient.Invoices.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Invoices.cs
@@ -1,0 +1,88 @@
+﻿using AndreasReitberger.API.LexOffice.Enum;
+#if !NETFRAMEWORK
+using AndreasReitberger.API.REST;
+#else
+using CommunityToolkit.Mvvm.ComponentModel;
+#endif
+using Newtonsoft.Json;
+using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
+    {
+        #region Invoices
+        public async Task<List<VoucherListContent>> GetInvoiceListAsync(LexVoucherStatus status, bool archived = false, int page = 0, int size = 25, int pages = -1, int cooldown = 0)
+        {
+            List<VoucherListContent> result = [];
+            string cmd = $"voucherlist?voucherType={LexVoucherType.Invoice.ToString().ToLower()}" +
+                $"&voucherStatus={status.ToString().ToLower()}" +
+                $"&archived={archived}"
+                ;
+            cmd += $"&page={page}&size={size}";
+
+            string? jsonString = await BaseApiCallAsync<string>(cmd, Method.Get) ?? string.Empty;
+            LexVoucherList? list = JsonConvert.DeserializeObject<LexVoucherList>(jsonString);
+            if (list is not null)
+            {
+                if (list.TotalPages > 1 && page < list.TotalPages && (pages <= 0 || (pages - 1 > page && pages > 1)))
+                {
+                    result = new List<VoucherListContent>(list.Content);
+                    if (MinimumCooldown > 0 && cooldown > 0)
+                        await Task.Delay(cooldown < MinimumCooldown ? MinimumCooldown : cooldown);
+                    page++;
+                    List<VoucherListContent> append = await GetInvoiceListAsync(status, archived, page, size, pages, cooldown);
+                    result = new List<VoucherListContent>(result.Concat(append));
+                    return result;
+                }
+                else
+                    result = new List<VoucherListContent>(list.Content);
+            }
+            return result;
+        }
+
+        public async Task<List<LexDocumentResponse>> GetInvoicesAsync(List<Guid> ids, int cooldown = 0)
+        {
+            List<LexDocumentResponse> result = [];
+            foreach (Guid id in ids)
+            {
+                LexDocumentResponse? quote = await GetInvoiceAsync(id);
+                if (quote is not null)
+                    result.Add(quote);
+                await Task.Delay(cooldown < MinimumCooldown ? MinimumCooldown : cooldown);
+            }
+            return result;
+        }
+
+        public async Task<List<LexDocumentResponse>> GetInvoicesAsync(List<VoucherListContent> voucherList)
+        {
+            List<Guid> ids = voucherList.Select(id => id.Id).ToList();
+            return await GetInvoicesAsync(ids);
+        }
+
+        public async Task<LexDocumentResponse?> GetInvoiceAsync(Guid id)
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"invoices/{id}", Method.Get) ?? string.Empty;
+            LexDocumentResponse? response = JsonConvert.DeserializeObject<LexDocumentResponse>(jsonString);
+            return response;
+        }
+
+        public async Task<LexResponseDefault?> AddInvoiceAsync(LexDocumentResponse lexQuotation, bool isFinalized = false)
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"invoices?finalize={isFinalized}", Method.Post, JsonConvert.SerializeObject(lexQuotation, JsonSerializerSettings)) ?? string.Empty;
+            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
+            return response;
+        }
+        #endregion
+    }
+}

--- a/src/LexOfficeSharpApi/LexOfficeClient.Invoices.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Invoices.cs
@@ -112,7 +112,11 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                LexVoucherList? list = GetObjectFromJson<LexVoucherList>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                if (result?.Succeeded is false)
+                {
+                    ThrowOnError(respone: result, methodName: nameof(GetInvoiceListAsync));
+                }
+                LexVoucherList? list = GetObjectFromJson<LexVoucherList>(result?.Result, NewtonsoftJsonSerializerSettings);
                 if (list is not null)
                 {
                     if (list.TotalPages > 1 && page < list.TotalPages && (pages <= 0 || (pages - 1 > page && pages > 1)))
@@ -173,7 +177,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexDocumentResponse>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexDocumentResponse>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)
@@ -204,7 +208,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)

--- a/src/LexOfficeSharpApi/LexOfficeClient.NetFramework.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.NetFramework.cs
@@ -1,0 +1,147 @@
+﻿
+#if NETFRAMEWORK
+using CommunityToolkit.Mvvm.ComponentModel;
+using Newtonsoft.Json;
+using RestSharp;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Xml.Serialization;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    /*  .NET Framework is not supported by the RestApiClient, so keep this properties for know in a separat file.
+     *  In the future, the support of .NET Framework will be dropped.
+     */
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient : ObservableObject
+    {
+
+        #region Properties
+
+        [ObservableProperty]
+        public partial bool IsActive { get; set; } = false;
+
+        [ObservableProperty]
+        public partial bool IsInitialized { get; set; } = false;
+
+        [ObservableProperty]
+        [JsonIgnore, XmlIgnore]
+        public partial RestClient? RestClient { get; set; }
+
+        [ObservableProperty]
+        [JsonIgnore, XmlIgnore]
+        public partial HttpClient? HttpClient { get; set; }
+
+        [ObservableProperty]
+        public partial bool UpdatingClients { get; set; } = false;
+
+        [ObservableProperty]
+        public partial string ApiTargetPath { get; set; } = "https://api.lexoffice.io/";
+        partial void OnApiTargetPathChanged(string value) => UpdateRestClientInstance();
+
+        [ObservableProperty]
+        public partial string ApiVersion { get; set; } = "v1";
+        partial void OnApiVersionChanged(string value) => UpdateRestClientInstance();
+
+        [ObservableProperty]
+        [JsonIgnore, XmlIgnore]
+        public partial bool IsConnecting { get; set; } = false;
+
+        [field: JsonIgnore, XmlIgnore]
+
+        [ObservableProperty]
+        [JsonIgnore, XmlIgnore]
+        public partial bool IsOnline { get; set; } = false;
+
+        [ObservableProperty]
+        [JsonIgnore, XmlIgnore]
+        public partial bool IsAccessTokenValid { get; set; } = false;
+
+        [ObservableProperty]
+        public partial int DefaultTimeout { get; set; } = 10000;
+
+        [ObservableProperty]
+        public partial int MinimumCooldown { get; set; } = 0;
+        #endregion
+
+        #region Methods
+        public async Task CheckOnlineAsync(int timeout = 10000)
+        {
+            if (IsConnecting) return; // Avoid multiple calls
+            IsConnecting = true;
+            bool isReachable = false;
+            try
+            {
+                // Cancel after timeout
+                CancellationTokenSource cts = new(new TimeSpan(0, 0, 0, 0, timeout));
+                string uriString = $"{ApiTargetPath}";
+                try
+                {
+                    if (HttpClient is not null)
+                    {
+                        HttpResponseMessage? response = await HttpClient.GetAsync(uriString, cts.Token).ConfigureAwait(false);
+                        response.EnsureSuccessStatusCode();
+                        if (response != null)
+                        {
+                            isReachable = response.IsSuccessStatusCode;
+                        }
+                    }
+                }
+                catch (InvalidOperationException iexc)
+                {
+                    OnError(new UnhandledExceptionEventArgs(iexc, false));
+                }
+                catch (HttpRequestException rexc)
+                {
+                    OnError(new UnhandledExceptionEventArgs(rexc, false));
+                }
+                catch (TaskCanceledException)
+                {
+                    // Throws exception on timeout, not actually an error
+                }
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+            }
+            IsConnecting = false;
+            IsOnline = isReachable;
+            //return isReachable;
+        }
+
+        void UpdateRestClientInstance()
+        {
+            if (string.IsNullOrEmpty(ApiTargetPath) || string.IsNullOrEmpty(ApiVersion) || UpdatingClients)
+            {
+                return;
+            }
+            UpdatingClients = true;
+            RestClientOptions options = new($"{ApiTargetPath}{ApiVersion}/")
+            {
+                ThrowOnAnyError = false,
+                Timeout = TimeSpan.FromSeconds(DefaultTimeout / 1000),
+            };
+            if (EnableProxy && !string.IsNullOrEmpty(ProxyAddress))
+            {
+                HttpClientHandler httpHandler = new()
+                {
+                    UseProxy = true,
+                    Proxy = GetCurrentProxy(),
+                    AllowAutoRedirect = true,
+                };
+
+                HttpClient = new(handler: httpHandler, disposeHandler: true);
+            }
+            else
+            {
+                HttpClient = new();
+            }
+            RestClient = new(httpClient: HttpClient, options: options);
+            UpdatingClients = false;
+        }
+        #endregion
+    }
+}
+#endif

--- a/src/LexOfficeSharpApi/LexOfficeClient.Payments.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Payments.cs
@@ -1,11 +1,14 @@
 ﻿#if !NETFRAMEWORK
 using AndreasReitberger.API.REST;
+using AndreasReitberger.API.REST.Interfaces;
+
 #else
 using CommunityToolkit.Mvvm.ComponentModel;
 #endif
 using Newtonsoft.Json;
 using RestSharp;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace AndreasReitberger.API.LexOffice
@@ -19,6 +22,8 @@ namespace AndreasReitberger.API.LexOffice
 #endif
     {
         #region Payments
+
+#if NETFRAMEWORK
         public async Task<LexPayments?> GetPaymentsAsync(Guid invoiceId)
         {
             string? jsonString = await BaseApiCallAsync<string>($"payments/{invoiceId}", Method.Get);
@@ -26,6 +31,35 @@ namespace AndreasReitberger.API.LexOffice
             LexPayments? response = JsonConvert.DeserializeObject<LexPayments>(jsonString);
             return response;
         }
-        #endregion
+#else
+
+        public async Task<LexPayments?> GetPaymentsAsync(Guid invoiceId)
+        {
+            IRestApiRequestRespone? result = null;
+            LexPayments? resultObject = null;
+            try
+            {
+                string targetUri = $"payments/{invoiceId}";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Get,
+                       command: "",
+                       jsonObject: null,
+                       authHeaders: AuthHeaders,
+                       urlSegments: null,
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = GetObjectFromJson<LexPayments>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+#endif
+#endregion
     }
 }

--- a/src/LexOfficeSharpApi/LexOfficeClient.Payments.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Payments.cs
@@ -1,0 +1,31 @@
+﻿#if !NETFRAMEWORK
+using AndreasReitberger.API.REST;
+#else
+using CommunityToolkit.Mvvm.ComponentModel;
+#endif
+using Newtonsoft.Json;
+using RestSharp;
+using System;
+using System.Threading.Tasks;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
+    {
+        #region Payments
+        public async Task<LexPayments?> GetPaymentsAsync(Guid invoiceId)
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"payments/{invoiceId}", Method.Get);
+            if (jsonString is null) return null;
+            LexPayments? response = JsonConvert.DeserializeObject<LexPayments>(jsonString);
+            return response;
+        }
+        #endregion
+    }
+}

--- a/src/LexOfficeSharpApi/LexOfficeClient.Payments.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Payments.cs
@@ -50,7 +50,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexPayments>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexPayments>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)

--- a/src/LexOfficeSharpApi/LexOfficeClient.Proxy.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Proxy.cs
@@ -1,0 +1,83 @@
+﻿
+#if NETFRAMEWORK
+using CommunityToolkit.Mvvm.ComponentModel;
+using Newtonsoft.Json;
+using System;
+using System.Net;
+using System.Xml.Serialization;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient : ObservableObject
+    {
+
+        #region Properties
+
+
+        [ObservableProperty]
+        public partial bool EnableProxy { get; set; } = false;
+
+        partial void OnEnableProxyChanged(bool value) => UpdateRestClientInstance();
+
+        [ObservableProperty]
+        public partial bool ProxyUseDefaultCredentials { get; set; } = true;
+
+        partial void OnProxyUseDefaultCredentialsChanged(bool value) => UpdateRestClientInstance();
+
+        [ObservableProperty]
+        public partial bool SecureProxyConnection { get; set; } = true;
+
+        partial void OnSecureProxyConnectionChanged(bool value) => UpdateRestClientInstance();
+
+        [ObservableProperty]
+        public partial string ProxyAddress { get; set; } = string.Empty;
+
+        partial void OnProxyAddressChanged(string value) => UpdateRestClientInstance();
+
+        [ObservableProperty]
+        public partial int ProxyPort { get; set; } = 443;
+
+        partial void OnProxyPortChanged(int value) => UpdateRestClientInstance();
+
+        [ObservableProperty]
+        public partial string ProxyUser { get; set; } = string.Empty;
+
+        partial void OnProxyUserChanged(string value) => UpdateRestClientInstance();
+
+        [ObservableProperty]
+        [JsonIgnore, XmlIgnore]
+        public partial string? ProxyPassword { get; set; }
+
+        partial void OnProxyPasswordChanged(string? value) => UpdateRestClientInstance();
+
+        #endregion
+
+        #region Methods
+
+        Uri GetProxyUri() =>
+            ProxyAddress.StartsWith("http://") || ProxyAddress.StartsWith("https://") ? new Uri($"{ProxyAddress}:{ProxyPort}") : new Uri($"{(SecureProxyConnection ? "https" : "http")}://{ProxyAddress}:{ProxyPort}");
+
+        WebProxy GetCurrentProxy()
+        {
+            WebProxy proxy = new()
+            {
+                Address = GetProxyUri(),
+                BypassProxyOnLocal = false,
+                UseDefaultCredentials = ProxyUseDefaultCredentials,
+            };
+            if (ProxyUseDefaultCredentials && !string.IsNullOrEmpty(ProxyUser))
+            {
+                proxy.Credentials = new NetworkCredential(ProxyUser, ProxyPassword);
+            }
+            else
+            {
+                proxy.UseDefaultCredentials = ProxyUseDefaultCredentials;
+            }
+            return proxy;
+        }
+#endregion
+
+    }
+}
+#endif

--- a/src/LexOfficeSharpApi/LexOfficeClient.Quotations.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Quotations.cs
@@ -101,7 +101,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                LexVoucherList? list = GetObjectFromJson<LexVoucherList>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                LexVoucherList? list = GetObjectFromJson<LexVoucherList>(result?.Result, NewtonsoftJsonSerializerSettings);
                 if (list is not null)
                 {
                     if (list.TotalPages > 1 && page < list.TotalPages && (pages <= 0 || (pages - 1 > page && pages > 1)))
@@ -125,7 +125,7 @@ namespace AndreasReitberger.API.LexOffice
                 return resultObject;
             }
         }
-        public async Task<List<LexDocumentResponse>> GetQuotationsAsync(List<Guid> ids)
+        public async Task<List<LexDocumentResponse>> GetQuotationsAsync(List<Guid> ids, int cooldown = 50)
         {
             List<LexDocumentResponse> result = [];
             foreach (Guid Id in ids)
@@ -133,6 +133,8 @@ namespace AndreasReitberger.API.LexOffice
                 LexDocumentResponse? quote = await GetQuotationAsync(Id);
                 if (quote is not null)
                     result.Add(quote);
+                if (cooldown > 0)
+                    await Task.Delay(50);
             }
             return result;
         }
@@ -160,7 +162,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexDocumentResponse>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexDocumentResponse>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)

--- a/src/LexOfficeSharpApi/LexOfficeClient.Quotations.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Quotations.cs
@@ -1,0 +1,77 @@
+﻿using AndreasReitberger.API.LexOffice.Enum;
+#if !NETFRAMEWORK
+using AndreasReitberger.API.REST;
+#else
+using CommunityToolkit.Mvvm.ComponentModel;
+#endif
+using Newtonsoft.Json;
+using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
+    {
+        #region Quotations
+        public async Task<List<VoucherListContent>> GetQuotationListAsync(LexVoucherStatus status, bool archived = false, int page = 0, int size = 25)
+        {
+            List<VoucherListContent> result = [];
+            string cmd = $"voucherlist?voucherType={LexVoucherType.Quotation.ToString().ToLower()}" +
+                $"&voucherStatus={status.ToString().ToLower()}" +
+                $"&archived={archived}"
+                ;
+            cmd += $"&page={page}&size={size}";
+
+            string? jsonString = await BaseApiCallAsync<string>(cmd, Method.Get) ?? string.Empty;
+            LexVoucherList? list = JsonConvert.DeserializeObject<LexVoucherList>(jsonString);
+            if (list is not null)
+            {
+                if (page < list.TotalPages - 1)
+                {
+                    page++;
+                    result = new List<VoucherListContent>(list.Content);
+                    List<VoucherListContent> append = await GetQuotationListAsync(status, archived, page, size);
+                    result = new List<VoucherListContent>(result.Concat(append));
+                    return result;
+                }
+            }
+            return result;
+        }
+
+        public async Task<List<LexDocumentResponse>> GetQuotationsAsync(List<Guid> ids)
+        {
+            List<LexDocumentResponse> result = [];
+            foreach (Guid Id in ids)
+            {
+                LexDocumentResponse? quote = await GetQuotationAsync(Id);
+                if (quote is not null)
+                    result.Add(quote);
+            }
+            return result;
+        }
+
+        public async Task<List<LexDocumentResponse>> GetQuotationsAsync(List<VoucherListContent> voucherList)
+        {
+            List<Guid> ids = [.. voucherList.Select(id => id.Id)];
+            return await GetQuotationsAsync(ids);
+        }
+
+        public async Task<LexDocumentResponse?> GetQuotationAsync(Guid id)
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"quotations/{id}", Method.Get);
+            if (jsonString is null) return null;
+            LexDocumentResponse? response = JsonConvert.DeserializeObject<LexDocumentResponse>(jsonString);
+            return response;
+        }
+        #endregion
+    }
+}

--- a/src/LexOfficeSharpApi/LexOfficeClient.Subscriptions.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Subscriptions.cs
@@ -68,7 +68,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)
@@ -95,7 +95,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)
@@ -122,7 +122,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexResponseWrapper>(result?.Result, base.NewtonsoftJsonSerializerSettings)?.Content;
+                resultObject = GetObjectFromJson<LexResponseWrapper>(result?.Result, NewtonsoftJsonSerializerSettings)?.Content;
                 return resultObject;
             }
             catch (Exception exc)
@@ -149,7 +149,7 @@ namespace AndreasReitberger.API.LexOffice
                        cts: default
                        )
                     .ConfigureAwait(false);
-                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, NewtonsoftJsonSerializerSettings);
                 return resultObject;
             }
             catch (Exception exc)

--- a/src/LexOfficeSharpApi/LexOfficeClient.Subscriptions.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Subscriptions.cs
@@ -1,5 +1,6 @@
 ﻿#if !NETFRAMEWORK
 using AndreasReitberger.API.REST;
+using AndreasReitberger.API.REST.Interfaces;
 #else
 using CommunityToolkit.Mvvm.ComponentModel;
 #endif
@@ -20,9 +21,10 @@ namespace AndreasReitberger.API.LexOffice
 #endif
     {
         #region Subscription
+#if NETFRAMEWORK
         public async Task<LexResponseDefault?> AddEventSubscriptionAsync(LexResponseDefault lexQuotation)
         {
-            string json = JsonConvert.SerializeObject(lexQuotation, JsonSerializerSettings) ?? string.Empty;
+            string json = JsonConvert.SerializeObject(lexQuotation, NewtonsoftJsonSerializerSettings) ?? string.Empty;
             string? jsonString = await BaseApiCallAsync<string>($"event-subscriptions", Method.Post, json);
             if (jsonString is null) return null;
             LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
@@ -46,6 +48,117 @@ namespace AndreasReitberger.API.LexOffice
         }
 
         public Task DeleteEventSubscriptionAsync(Guid? id) => BaseApiCallAsync<string>($"event-subscriptions/{id}", Method.Delete);
-        #endregion
+#else
+
+        public async Task<LexResponseDefault?> AddEventSubscriptionAsync(LexResponseDefault lexQuotation)
+        {
+            IRestApiRequestRespone? result = null;
+            LexResponseDefault? resultObject = null;
+            try
+            {
+                string json = JsonConvert.SerializeObject(lexQuotation, NewtonsoftJsonSerializerSettings);
+                string targetUri = $"event-subscriptions";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Post,
+                       command: "",
+                       jsonObject: json,
+                       authHeaders: AuthHeaders,
+                       urlSegments: null,
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+
+        public async Task<LexResponseDefault?> GetEventSubscriptionAsync(Guid? id)
+        {
+            IRestApiRequestRespone? result = null;
+            LexResponseDefault? resultObject = null;
+            try
+            {
+                string targetUri = $"event-subscriptions/{id}";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Get,
+                       command: "",
+                       jsonObject: null,
+                       authHeaders: AuthHeaders,
+                       urlSegments: null,
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+
+        public async Task<List<LexResponseDefault>?> GetAllEventSubscriptionsAsync()
+        {
+            IRestApiRequestRespone? result = null;
+            List<LexResponseDefault>? resultObject = [];
+            try
+            {
+                string targetUri = $"event-subscriptions";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Get,
+                       command: "",
+                       jsonObject: null,
+                       authHeaders: AuthHeaders,
+                       urlSegments: null,
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = GetObjectFromJson<LexResponseWrapper>(result?.Result, base.NewtonsoftJsonSerializerSettings)?.Content;
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+
+        public async Task<LexResponseDefault?> DeleteEventSubscriptionAsync(Guid id)
+        {
+            IRestApiRequestRespone? result = null;
+            LexResponseDefault? resultObject = null;
+            try
+            {
+                string targetUri = $"event-subscriptions/{id}";
+                result = await SendRestApiRequestAsync(
+                       requestTargetUri: targetUri,
+                       method: Method.Delete,
+                       command: "",
+                       jsonObject: null,
+                       authHeaders: AuthHeaders,
+                       urlSegments: null,
+                       cts: default
+                       )
+                    .ConfigureAwait(false);
+                resultObject = GetObjectFromJson<LexResponseDefault>(result?.Result, base.NewtonsoftJsonSerializerSettings);
+                return resultObject;
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return resultObject;
+            }
+        }
+#endif
+    #endregion
     }
 }

--- a/src/LexOfficeSharpApi/LexOfficeClient.Subscriptions.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.Subscriptions.cs
@@ -1,0 +1,51 @@
+﻿#if !NETFRAMEWORK
+using AndreasReitberger.API.REST;
+#else
+using CommunityToolkit.Mvvm.ComponentModel;
+#endif
+using Newtonsoft.Json;
+using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AndreasReitberger.API.LexOffice
+{
+    // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
+    {
+        #region Subscription
+        public async Task<LexResponseDefault?> AddEventSubscriptionAsync(LexResponseDefault lexQuotation)
+        {
+            string json = JsonConvert.SerializeObject(lexQuotation, JsonSerializerSettings) ?? string.Empty;
+            string? jsonString = await BaseApiCallAsync<string>($"event-subscriptions", Method.Post, json);
+            if (jsonString is null) return null;
+            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
+            return response;
+        }
+
+        public async Task<LexResponseDefault?> GetEventSubscriptionAsync(Guid? id)
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"event-subscriptions/{id}");
+            if (jsonString is null) return null;
+            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
+            return response;
+        }
+
+        public async Task<List<LexResponseDefault>?> GetAllEventSubscriptionsAsync()
+        {
+            string? jsonString = await BaseApiCallAsync<string>($"event-subscriptions", Method.Get);
+            if (jsonString is null) return null;
+            List<LexResponseDefault>? response = JsonConvert.DeserializeObject<LexResponseWrapper>(jsonString)?.Content;
+            return response;
+        }
+
+        public Task DeleteEventSubscriptionAsync(Guid? id) => BaseApiCallAsync<string>($"event-subscriptions/{id}", Method.Delete);
+        #endregion
+    }
+}

--- a/src/LexOfficeSharpApi/LexOfficeClient.cs
+++ b/src/LexOfficeSharpApi/LexOfficeClient.cs
@@ -1,31 +1,38 @@
-﻿using AndreasReitberger.API.LexOffice.Enum;
-using AndreasReitberger.API.LexOffice.Utilities;
+﻿#if !NETFRAMEWORK
+using AndreasReitberger.API.REST;
+#endif
 using AndreasReitberger.Core.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
-using System.Threading.RateLimiting;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 
 namespace AndreasReitberger.API.LexOffice
 {
     // https://developers.lexoffice.io/docs/#lexoffice-api-documentation/?cid=1766
-    public partial class LexOfficeClient : ObservableObject
+    public partial class LexOfficeClient
+#if NETFRAMEWORK
+       : ObservableObject
+#else
+       : RestApiClient
+#endif
     {
 
         #region Instance
         static LexOfficeClient? _instance = null;
         static readonly object Lock = new();
+#if NETFRAMEWORK
         public static LexOfficeClient Instance
+#else
+        public new static LexOfficeClient Instance
+#endif
         {
             get
             {
@@ -45,12 +52,6 @@ namespace AndreasReitberger.API.LexOffice
             }
         }
 
-        [ObservableProperty]
-        bool isActive = false;
-
-        [ObservableProperty]
-        bool isInitialized = false;
-
         #endregion
 
         #region Static
@@ -60,54 +61,10 @@ namespace AndreasReitberger.API.LexOffice
 
         #region Properties
 
-        #region Clients
-
-        [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
-        RestClient? restClient;
-        //partial void OnRestClientChanged(RestClient? value) => UpdateRestClientInstance();
-
-        [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
-        HttpClient? httpClient;
-        //partial void OnHttpClientChanged(HttpClient? value) => UpdateRestClientInstance();
-
-#if !NETFRAMEWORK
-        [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
-        RateLimitedHandler? rateLimitedHandler;
-
-        public static RateLimiter DefaultLimiter = new TokenBucketRateLimiter(new()
-        {
-            TokenLimit = 2,
-            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-            QueueLimit = int.MaxValue,
-            ReplenishmentPeriod = TimeSpan.FromSeconds(1),
-            TokensPerPeriod = 1,
-            AutoReplenishment = true,
-        });
-
-        [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
-        RateLimiter? limiter;
-        partial void OnLimiterChanged(RateLimiter? value) => UpdateRestClientInstance();
-#endif
-        [ObservableProperty]
-        bool updatingClients = false;
-
-        [ObservableProperty]
-        string appBaseUrl = "https://api.lexoffice.io/";
-        partial void OnAppBaseUrlChanged(string value) => UpdateRestClientInstance();
-
-        [ObservableProperty]
-        string apiVersion = "v1";
-        partial void OnApiVersionChanged(string value) => UpdateRestClientInstance();
-        #endregion
-
         #region SerializerSettings
 
         [ObservableProperty]
-        JsonSerializerSettings jsonSerializerSettings = new()
+        public partial JsonSerializerSettings JsonSerializerSettings { get; set; } = new()
         {
             Formatting = Formatting.Indented,
             ContractResolver = new DefaultContractResolver
@@ -122,67 +79,17 @@ namespace AndreasReitberger.API.LexOffice
         #region General
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
-        string? accessToken = null;
+        [JsonIgnore, XmlIgnore]
+        public partial string? AccessToken { get; set; } = null;
+
         partial void OnAccessTokenChanged(string? value) => VerifyAccessToken();
 
-        [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
-        bool isConnecting = false;
-        [JsonIgnore, XmlIgnore]
-
-        [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
-        bool isOnline = false;
-
-        [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
-        bool isAccessTokenValid = false;
-
-        [ObservableProperty]
-        int defaultTimeout = 10000;
-
-        [ObservableProperty]
-        int minimumCooldown = 0;
-
         #endregion
 
-        #region Proxy
+#endregion
 
-        [ObservableProperty]
-        bool enableProxy = false;
-        partial void OnEnableProxyChanged(bool value) => UpdateRestClientInstance();
-
-        [ObservableProperty]
-        bool proxyUseDefaultCredentials = true;
-        partial void OnProxyUseDefaultCredentialsChanged(bool value) => UpdateRestClientInstance();
-
-        [ObservableProperty]
-        bool secureProxyConnection = true;
-        partial void OnSecureProxyConnectionChanged(bool value) => UpdateRestClientInstance();
-
-        [ObservableProperty]
-        string proxyAddress = string.Empty;
-        partial void OnProxyAddressChanged(string value) => UpdateRestClientInstance();
-
-        [ObservableProperty]
-        int proxyPort = 443;
-        partial void OnProxyPortChanged(int value) => UpdateRestClientInstance();
-
-        [ObservableProperty]
-        string proxyUser = string.Empty;
-        partial void OnProxyUserChanged(string value) => UpdateRestClientInstance();
-
-        [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
-        string? proxyPassword;
-        partial void OnProxyPasswordChanged(string? value) => UpdateRestClientInstance();
-
-        #endregion
-
-        #endregion
-
-        #region EventHandlers
+#region EventHandlers
+#if NETFRAMEWORK
         public event EventHandler? Error;
         protected virtual void OnError()
         {
@@ -192,7 +99,8 @@ namespace AndreasReitberger.API.LexOffice
         {
             Error?.Invoke(this, e);
         }
-        #endregion
+#endif
+#endregion
 
         #region Constructor
         public LexOfficeClient()
@@ -208,47 +116,10 @@ namespace AndreasReitberger.API.LexOffice
         #endregion
 
         #region Methods
-        void UpdateRestClientInstance()
-        {
-            if (string.IsNullOrEmpty(AppBaseUrl) || string.IsNullOrEmpty(ApiVersion) || UpdatingClients)
-            {
-                return;
-            }
-            UpdatingClients = true;
-#if !NETFRAMEWORK
-            Limiter ??= DefaultLimiter;
-#endif
-            RestClientOptions options = new($"{AppBaseUrl}{ApiVersion}/")
-            {
-                ThrowOnAnyError = false,
-                Timeout = TimeSpan.FromSeconds(DefaultTimeout / 1000),
-            };
-            if (EnableProxy && !string.IsNullOrEmpty(ProxyAddress))
-            {
-                HttpClientHandler httpHandler = new()
-                {
-                    UseProxy = true,
-                    Proxy = GetCurrentProxy(),
-                    AllowAutoRedirect = true,
-                };
+#if NETFRAMEWORK
 
-                HttpClient = new(handler: httpHandler, disposeHandler: true);
-                //RestClient = new(httpClient: HttpClient, options: options);
-            }
-            else
-            {
-                HttpClient =
-#if !NETFRAMEWORK
-                    new(new RateLimitedHandler(Limiter));
-#else
-                    new();
 #endif
-                //RestClient = new(baseUrl: $"{AppBaseUrl}{ApiVersion}/");
-            }
-            RestClient = new(httpClient: HttpClient, options: options);
-            UpdatingClients = false;
-        }
-
+        [Obsolete("In the future, use `SendRestApiRequestAsync` from the `RestApiClient`!")]
         async Task<T?> BaseApiCallAsync<T>(string command, Method method = Method.Get, string body = "", CancellationTokenSource? cts = default) where T : class
         {
             if (cts == default)
@@ -320,355 +191,6 @@ namespace AndreasReitberger.API.LexOffice
                 OnError(new UnhandledExceptionEventArgs(exc, false));
             }
         }
-        #endregion
-
-        #region Public Methods
-
-        #region Proxy
-        Uri GetProxyUri() =>
-            ProxyAddress.StartsWith("http://") || ProxyAddress.StartsWith("https://") ? new Uri($"{ProxyAddress}:{ProxyPort}") : new Uri($"{(SecureProxyConnection ? "https" : "http")}://{ProxyAddress}:{ProxyPort}");
-
-        WebProxy GetCurrentProxy()
-        {
-            WebProxy proxy = new()
-            {
-                Address = GetProxyUri(),
-                BypassProxyOnLocal = false,
-                UseDefaultCredentials = ProxyUseDefaultCredentials,
-            };
-            if (ProxyUseDefaultCredentials && !string.IsNullOrEmpty(ProxyUser))
-            {
-                proxy.Credentials = new NetworkCredential(ProxyUser, ProxyPassword);
-            }
-            else
-            {
-                proxy.UseDefaultCredentials = ProxyUseDefaultCredentials;
-            }
-            return proxy;
-        }
-        #endregion
-
-        #region SetAccessToken
-        public void SetAccessToken(string token)
-        {
-            AccessToken = token;
-            IsInitialized = true;
-        }
-        #endregion
-
-        #region OnlineCheck
-        public async Task CheckOnlineAsync(int timeout = 10000)
-        {
-            if (IsConnecting) return; // Avoid multiple calls
-            IsConnecting = true;
-            bool isReachable = false;
-            try
-            {
-                // Cancel after timeout
-                CancellationTokenSource cts = new(new TimeSpan(0, 0, 0, 0, timeout));
-                string uriString = $"{AppBaseUrl}";
-                try
-                {
-                    if (HttpClient is not null)
-                    {
-                        HttpResponseMessage? response = await HttpClient.GetAsync(uriString, cts.Token).ConfigureAwait(false);
-                        response.EnsureSuccessStatusCode();
-                        if (response != null)
-                        {
-                            isReachable = response.IsSuccessStatusCode;
-                        }
-                    }
-                }
-                catch (InvalidOperationException iexc)
-                {
-                    OnError(new UnhandledExceptionEventArgs(iexc, false));
-                }
-                catch (HttpRequestException rexc)
-                {
-                    OnError(new UnhandledExceptionEventArgs(rexc, false));
-                }
-                catch (TaskCanceledException)
-                {
-                    // Throws exception on timeout, not actually an error
-                }
-            }
-            catch (Exception exc)
-            {
-                OnError(new UnhandledExceptionEventArgs(exc, false));
-            }
-            IsConnecting = false;
-            IsOnline = isReachable;
-            //return isReachable;
-        }
-        #endregion
-
-        #region Contacts
-        public async Task<List<LexContact>> GetContactsAsync(LexContactType type, int page = 0, int size = 25, int pages = -1, int cooldown = 0)
-        {
-            List<LexContact> result = [];
-            string cmd = $"contacts?{(type == LexContactType.Customer ? "customer" : "vendor")}=true";
-            cmd += $"&page={page}&size={size}";
-
-            string? jsonString = await BaseApiCallAsync<string>(cmd, Method.Get) ?? string.Empty;
-            LexContactsList? list = JsonConvert.DeserializeObject<LexContactsList>(jsonString);
-            if (list != null)
-            {
-                if (list.TotalPages > 1 && page < list.TotalPages && (pages <= 0 || (pages - 1 > page && pages > 1)))
-                {
-                    result = new List<LexContact>(list.Content);
-                    if (MinimumCooldown > 0 && cooldown > 0)
-                        await Task.Delay(cooldown < MinimumCooldown ? MinimumCooldown : cooldown);
-                    page++;
-                    List<LexContact> append = await GetContactsAsync(type, page, size, pages, cooldown);
-                    result = new List<LexContact>(result.Concat(append));
-                    return result;
-                }
-                else
-                    result = new List<LexContact>(list.Content);
-            }
-            return result;
-        }
-
-        public async Task<LexContact?> GetContactAsync(Guid id)
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"contacts/{id}", Method.Get) ?? string.Empty;
-            LexContact? contact = JsonConvert.DeserializeObject<LexContact>(jsonString);
-            return contact;
-        }
-
-        public async Task<LexResponseDefault?> AddContactAsync(LexContact lexContact)
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"contacts", Method.Post, JsonConvert.SerializeObject(lexContact, JsonSerializerSettings)) ?? string.Empty;
-            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
-            return response;
-        }
-
-        public async Task<LexResponseDefault?> UpdateContactAsync(Guid contactId, LexContact lexContact)
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"contacts/{contactId}", Method.Post, JsonConvert.SerializeObject(lexContact, JsonSerializerSettings)) ?? string.Empty;
-            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
-            return response;
-        }
-        #endregion
-
-        #region Countries
-
-        public async Task<List<LexCountry>> GetCountriesAsync()
-        {
-            List<LexCountry> result = [];
-            string? jsonString = await BaseApiCallAsync<string>("countries", Method.Get) ?? string.Empty;
-            result = JsonConvert.DeserializeObject<List<LexCountry>>(jsonString) ?? [];
-            return result;
-        }
-        #endregion
-
-        #region Credit Notes
-
-        public async Task<List<LexDocumentResponse>> GetCreditNotesAsync()
-        {
-            List<LexDocumentResponse> result = [];
-            string? jsonString = await BaseApiCallAsync<string>("credit-notes", Method.Get) ?? string.Empty;
-            result = JsonConvert.DeserializeObject<List<LexDocumentResponse>>(jsonString) ?? [];
-            return result;
-        }
-
-        public async Task<LexDocumentResponse?> GetCreditNoteAsync(Guid id)
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"credit-notes/{id}", Method.Get) ?? string.Empty;
-            LexDocumentResponse? respone = JsonConvert.DeserializeObject<LexDocumentResponse>(jsonString);
-            return respone;
-        }
-
-        public async Task<LexResponseDefault?> AddCreditNoteAsync(LexDocumentResponse lexQuotation, bool isFinalized = false)
-        {
-            var body = JsonConvert.SerializeObject(lexQuotation, JsonSerializerSettings);
-            string? jsonString = await BaseApiCallAsync<string>($"credit-notes/?finalize={isFinalized}", Method.Post, body) ?? string.Empty;
-            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
-            return response;
-        }
-        #endregion
-
-        #region Conditions
-
-        public async Task<List<LexQuotationPaymentConditions>> GetPaymentConditionsAsync()
-        {
-            List<LexQuotationPaymentConditions> result = [];
-            string? jsonString = await BaseApiCallAsync<string>($"payment-conditions", Method.Get) ?? string.Empty;
-            result = JsonConvert.DeserializeObject<List<LexQuotationPaymentConditions>>(jsonString) ?? [];
-            return result;
-        }
-        #endregion
-
-        #region Invoices
-        public async Task<List<VoucherListContent>> GetInvoiceListAsync(LexVoucherStatus status, bool archived = false, int page = 0, int size = 25, int pages = -1, int cooldown = 0)
-        {
-            List<VoucherListContent> result = [];
-            string cmd = $"voucherlist?voucherType={LexVoucherType.Invoice.ToString().ToLower()}" +
-                $"&voucherStatus={status.ToString().ToLower()}" +
-                $"&archived={archived}"
-                ;
-            cmd += $"&page={page}&size={size}";
-
-            string? jsonString = await BaseApiCallAsync<string>(cmd, Method.Get) ?? string.Empty;
-            LexVoucherList? list = JsonConvert.DeserializeObject<LexVoucherList>(jsonString);
-            if (list is not null)
-            {
-                if (list.TotalPages > 1 && page < list.TotalPages && (pages <= 0 || (pages - 1 > page && pages > 1)))
-                {
-                    result = new List<VoucherListContent>(list.Content);
-                    if (MinimumCooldown > 0 && cooldown > 0)
-                        await Task.Delay(cooldown < MinimumCooldown ? MinimumCooldown : cooldown);
-                    page++;
-                    List<VoucherListContent> append = await GetInvoiceListAsync(status, archived, page, size, pages, cooldown);
-                    result = new List<VoucherListContent>(result.Concat(append));
-                    return result;
-                }
-                else
-                    result = new List<VoucherListContent>(list.Content);
-            }
-            return result;
-        }
-
-        public async Task<List<LexDocumentResponse>> GetInvoicesAsync(List<Guid> ids, int cooldown = 0)
-        {
-            List<LexDocumentResponse> result = [];
-            foreach (Guid id in ids)
-            {
-                LexDocumentResponse? quote = await GetInvoiceAsync(id);
-                if (quote is not null)
-                    result.Add(quote);
-                await Task.Delay(cooldown < MinimumCooldown ? MinimumCooldown : cooldown);
-            }
-            return result;
-        }
-
-        public async Task<List<LexDocumentResponse>> GetInvoicesAsync(List<VoucherListContent> voucherList)
-        {
-            List<Guid> ids = voucherList.Select(id => id.Id).ToList();
-            return await GetInvoicesAsync(ids);
-        }
-
-        public async Task<LexDocumentResponse?> GetInvoiceAsync(Guid id)
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"invoices/{id}", Method.Get) ?? string.Empty;
-            LexDocumentResponse? response = JsonConvert.DeserializeObject<LexDocumentResponse>(jsonString);
-            return response;
-        }
-
-        public async Task<LexResponseDefault?> AddInvoiceAsync(LexDocumentResponse lexQuotation, bool isFinalized = false)
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"invoices?finalize={isFinalized}", Method.Post, JsonConvert.SerializeObject(lexQuotation, JsonSerializerSettings)) ?? string.Empty;
-            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
-            return response;
-        }
-        #endregion
-
-        #region Subscription
-        public async Task<LexResponseDefault?> AddEventSubscriptionAsync(LexResponseDefault lexQuotation)
-        {
-            string json = JsonConvert.SerializeObject(lexQuotation, JsonSerializerSettings) ?? string.Empty;
-            string? jsonString = await BaseApiCallAsync<string>($"event-subscriptions", Method.Post, json);
-            if (jsonString is null) return null;
-            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
-            return response;
-        }
-
-        public async Task<LexResponseDefault?> GetEventSubscriptionAsync(Guid? id)
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"event-subscriptions/{id}");
-            if (jsonString is null) return null;
-            LexResponseDefault? response = JsonConvert.DeserializeObject<LexResponseDefault>(jsonString);
-            return response;
-        }
-
-        public async Task<List<LexResponseDefault>?> GetAllEventSubscriptionsAsync()
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"event-subscriptions", Method.Get);
-            if (jsonString is null) return null;
-            List<LexResponseDefault>? response = JsonConvert.DeserializeObject<LexResponseWrapper>(jsonString)?.Content;
-            return response;
-        }
-
-        public Task DeleteEventSubscriptionAsync(Guid? id) => BaseApiCallAsync<string>($"event-subscriptions/{id}", Method.Delete);
-        #endregion
-
-        #region Payments
-        public async Task<LexPayments?> GetPaymentsAsync(Guid invoiceId)
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"payments/{invoiceId}", Method.Get);
-            if (jsonString is null) return null;
-            LexPayments? response = JsonConvert.DeserializeObject<LexPayments>(jsonString);
-            return response;
-        }
-        #endregion
-
-        #region Quotations
-        public async Task<List<VoucherListContent>> GetQuotationListAsync(LexVoucherStatus status, bool archived = false, int page = 0, int size = 25)
-        {
-            List<VoucherListContent> result = [];
-            string cmd = $"voucherlist?voucherType={LexVoucherType.Quotation.ToString().ToLower()}" +
-                $"&voucherStatus={status.ToString().ToLower()}" +
-                $"&archived={archived}"
-                ;
-            cmd += $"&page={page}&size={size}";
-
-            string? jsonString = await BaseApiCallAsync<string>(cmd, Method.Get) ?? string.Empty;
-            LexVoucherList? list = JsonConvert.DeserializeObject<LexVoucherList>(jsonString);
-            if (list is not null)
-            {
-                if (page < list.TotalPages - 1)
-                {
-                    page++;
-                    result = new List<VoucherListContent>(list.Content);
-                    List<VoucherListContent> append = await GetQuotationListAsync(status, archived, page, size);
-                    result = new List<VoucherListContent>(result.Concat(append));
-                    return result;
-                }
-            }
-            return result;
-        }
-
-        public async Task<List<LexDocumentResponse>> GetQuotationsAsync(List<Guid> ids)
-        {
-            List<LexDocumentResponse> result = [];
-            foreach (Guid Id in ids)
-            {
-                LexDocumentResponse? quote = await GetQuotationAsync(Id);
-                if (quote is not null)
-                    result.Add(quote);
-            }
-            return result;
-        }
-
-        public async Task<List<LexDocumentResponse>> GetQuotationsAsync(List<VoucherListContent> voucherList)
-        {
-            List<Guid> ids = [.. voucherList.Select(id => id.Id)];
-            return await GetQuotationsAsync(ids);
-        }
-
-        public async Task<LexDocumentResponse?> GetQuotationAsync(Guid id)
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"quotations/{id}", Method.Get);
-            if (jsonString is null) return null;
-            LexDocumentResponse? response = JsonConvert.DeserializeObject<LexDocumentResponse>(jsonString);
-            return response;
-        }
-        #endregion
-
-        #region Documents
-
-        public async Task<LexQuotationFiles?> RenderDocumentAsync(Guid invoiceId)
-        {
-            string? jsonString = await BaseApiCallAsync<string>($"invoices/{invoiceId}/document", Method.Get);
-            if (jsonString is null) return null;
-            LexQuotationFiles? response = JsonConvert.DeserializeObject<LexQuotationFiles>(jsonString);
-            return response;
-        }
-
-        public Task<byte[]?> GetFileAsync(Guid id) => BaseApiCallAsync<byte[]>($"files/{id}", Method.Get);
-
-        #endregion
-
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/LexOfficeConnectionBuilder.cs
+++ b/src/LexOfficeSharpApi/LexOfficeConnectionBuilder.cs
@@ -21,7 +21,7 @@ namespace AndreasReitberger.API.LexOffice
             {
                 return _client;
             }
-            public LexOfficeConnectionBuilder WithWebAddress(string webAddress)
+            public LexOfficeConnectionBuilder WithWebAddress(string webAddress = "https://api.lexoffice.io/")
             {
                 _client.ApiTargetPath = webAddress;
                 return this;

--- a/src/LexOfficeSharpApi/LexOfficeConnectionBuilder.cs
+++ b/src/LexOfficeSharpApi/LexOfficeConnectionBuilder.cs
@@ -2,8 +2,10 @@
 using AndreasReitberger.API.REST.Enums;
 using AndreasReitberger.API.REST.Interfaces;
 using AndreasReitberger.API.REST;
-#endif
 using System.Collections.Generic;
+using System.Threading.RateLimiting;
+using System;
+#endif
 
 namespace AndreasReitberger.API.LexOffice
 {
@@ -19,6 +21,8 @@ namespace AndreasReitberger.API.LexOffice
 
             public LexOfficeClient Build()
             {
+                if (string.IsNullOrEmpty(_client.ApiTargetPath))
+                    _client.ApiTargetPath = "https://api.lexoffice.io/";
                 return _client;
             }
             public LexOfficeConnectionBuilder WithWebAddress(string webAddress = "https://api.lexoffice.io/")
@@ -44,8 +48,43 @@ namespace AndreasReitberger.API.LexOffice
 #endif
                 return this;
             }
+#if !NETFRAMEWORK
 
-        #endregion
+            /// <summary>
+            /// Set the rate limiter for the rest api connection
+            /// </summary>
+            /// <param name="autoReplenishment"></param>
+            /// <param name="tokenLimit">Maximum number of tokens that can be in the bucket at any time</param>
+            /// <param name="tokensPerPeriod">Maximum number of tokens to be restored in each replenishment</param>
+            /// <param name="replenishmentPeriod">Enable auto replenishment</param>
+            /// <param name="queueLimit">Size of the queue</param>
+            /// <returns><c>RestApiConnectionBuilder</c></returns>
+            public LexOfficeConnectionBuilder WithRateLimiter(bool autoReplenishment, int tokenLimit, int tokensPerPeriod, double replenishmentPeriod, int queueLimit = int.MaxValue)
+            {
+                _client.Limiter = new TokenBucketRateLimiter(new()
+                {
+                    TokenLimit = tokenLimit,
+                    TokensPerPeriod = tokensPerPeriod,
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = queueLimit,
+                    ReplenishmentPeriod = TimeSpan.FromSeconds(replenishmentPeriod),
+                    AutoReplenishment = true,
+                });
+                return this;
+            }
+#endif
+
+            /// <summary>
+            /// Set the timeout for the connection in ms (default is 10000 ms)
+            /// </summary>
+            /// <param name="timeout">The timeout in ms</param>
+            /// <returns><c>RestApiConnectionBuilder</c></returns>
+            public LexOfficeConnectionBuilder WithTimeout(int timeout = 10000)
+            {
+                _client.DefaultTimeout = timeout;
+                return this;
+            }
+            #endregion
 
         }
     }

--- a/src/LexOfficeSharpApi/LexOfficeConnectionBuilder.cs
+++ b/src/LexOfficeSharpApi/LexOfficeConnectionBuilder.cs
@@ -1,4 +1,11 @@
-﻿namespace AndreasReitberger.API.LexOffice
+﻿#if !NETFRAMEWORK
+using AndreasReitberger.API.REST.Enums;
+using AndreasReitberger.API.REST.Interfaces;
+using AndreasReitberger.API.REST;
+#endif
+using System.Collections.Generic;
+
+namespace AndreasReitberger.API.LexOffice
 {
     public partial class LexOfficeClient
     {
@@ -14,14 +21,31 @@
             {
                 return _client;
             }
-
-            public LexOfficeConnectionBuilder WithApiKey(string apiKey)
+            public LexOfficeConnectionBuilder WithWebAddress(string webAddress)
             {
+                _client.ApiTargetPath = webAddress;
+                return this;
+            }
+#if NETFRAMEWORK
+            public LexOfficeConnectionBuilder WithApiKey(string apiKey)
+#else
+            public LexOfficeConnectionBuilder WithApiKey(string apiKey, string tokenName = "Authorization")
+#endif
+            {
+#if NETFRAMEWORK
                 _client.AccessToken = apiKey;
+#else
+                _client.AuthHeaders = new Dictionary<string, IAuthenticationHeader>() { { tokenName, new AuthenticationHeader()
+                    {
+                        Target = AuthenticationHeaderTarget.Header,
+                        Token = $"Bearer {apiKey}",
+                    }
+                } };
+#endif
                 return this;
             }
 
-            #endregion
+        #endregion
 
         }
     }

--- a/src/LexOfficeSharpApi/LexOfficeSharpApi.csproj
+++ b/src/LexOfficeSharpApi/LexOfficeSharpApi.csproj
@@ -23,26 +23,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
     <PackageReference Include="RestApiClientSharp">
-      <Version>1.0.1</Version>
+      <Version>1.0.2</Version>
     </PackageReference>
   </ItemGroup>
- <!--
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="RestApiClientSharp">
-      <Version>1.0.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8'">
-    <PackageReference Include="RestApiClientSharp">
-      <Version>1.0.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9'">
-    <PackageReference Include="RestApiClientSharp">
-      <Version>1.0.1</Version>
-    </PackageReference>
-  </ItemGroup>
-  -->
 </Project>

--- a/src/LexOfficeSharpApi/LexOfficeSharpApi.csproj
+++ b/src/LexOfficeSharpApi/LexOfficeSharpApi.csproj
@@ -21,9 +21,11 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">	
     <PackageReference Include="RestApiClientSharp">
-      <Version>1.0.2</Version>
+      <Version>1.0.3.1</Version>
     </PackageReference>
+    <!--<ProjectReference Include="..\..\..\RestApiClientSharp\src\RestApiClientSharp\RestApiClientSharp.csproj" />-->
   </ItemGroup>
+
 </Project>

--- a/src/LexOfficeSharpApi/LexOfficeSharpApi.csproj
+++ b/src/LexOfficeSharpApi/LexOfficeSharpApi.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RCoreSharp" Version="1.0.9" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
@@ -19,4 +20,29 @@
     <PackageReference Include="System.Threading.RateLimiting" Version="9.0.1" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+    <PackageReference Include="RestApiClientSharp">
+      <Version>1.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+ <!--
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="RestApiClientSharp">
+      <Version>1.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8'">
+    <PackageReference Include="RestApiClientSharp">
+      <Version>1.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9'">
+    <PackageReference Include="RestApiClientSharp">
+      <Version>1.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  -->
 </Project>

--- a/src/LexOfficeSharpApi/Model/Contact/LexContact.cs
+++ b/src/LexOfficeSharpApi/Model/Contact/LexContact.cs
@@ -8,37 +8,37 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        Guid id;
+        public partial Guid Id { get; set; }
 
         [ObservableProperty]
-        Guid organizationId;
+        public partial Guid OrganizationId { get; set; }
 
         [ObservableProperty]
-        long version;
+        public partial long Version { get; set; }
 
         [ObservableProperty]
-        Dictionary<string, LexCustomerNumber> roles = [];
+        public partial Dictionary<string, LexCustomerNumber> Roles { get; set; } = [];
 
         [ObservableProperty]
-        LexContactCompany? company;
+        public partial LexContactCompany? Company { get; set; }
 
         [ObservableProperty]
-        LexContactPerson? person;
+        public partial LexContactPerson? Person { get; set; }
 
         [ObservableProperty]
-        Dictionary<string, List<LexContactAddress>> addresses = [];
+        public partial Dictionary<string, List<LexContactAddress>> Addresses { get; set; } = [];
 
         [ObservableProperty]
-        Dictionary<string, List<string>> emailAddresses = [];
+        public partial Dictionary<string, List<string>> EmailAddresses { get; set; } = [];
 
         [ObservableProperty]
-        Dictionary<string, List<string>> phoneNumbers = [];
+        public partial Dictionary<string, List<string>> PhoneNumbers { get; set; } = [];
 
         [ObservableProperty]
-        string note = string.Empty;
+        public partial string Note { get; set; } = string.Empty;
 
         [ObservableProperty]
-        bool archived;
+        public partial bool Archived { get; set; }
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Contact/LexContactAddress.cs
+++ b/src/LexOfficeSharpApi/Model/Contact/LexContactAddress.cs
@@ -6,22 +6,22 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        string name = string.Empty;
+        public partial string Name { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string supplement = string.Empty;
+        public partial string Supplement { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string street = string.Empty;
+        public partial string Street { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string zip = string.Empty;
+        public partial string Zip { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string city = string.Empty;
+        public partial string City { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string countryCode = string.Empty;
+        public partial string CountryCode { get; set; } = string.Empty;
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Contact/LexContactCompany.cs
+++ b/src/LexOfficeSharpApi/Model/Contact/LexContactCompany.cs
@@ -7,19 +7,19 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        string name = string.Empty;
+        public partial string Name { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string taxNumber = string.Empty;
+        public partial string TaxNumber { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string vatRegistrationId = string.Empty;
+        public partial string VatRegistrationId { get; set; } = string.Empty;
 
         [ObservableProperty]
-        bool allowTaxFreeInvoices;
+        public partial bool AllowTaxFreeInvoices { get; set; }
 
         [ObservableProperty]
-        List<LexContactPerson> contactPersons = [];
+        public partial List<LexContactPerson> ContactPersons { get; set; } = [];
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Contact/LexContactPerson.cs
+++ b/src/LexOfficeSharpApi/Model/Contact/LexContactPerson.cs
@@ -6,22 +6,22 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        string salutation = string.Empty;
+        public partial string Salutation { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string firstName = string.Empty;
+        public partial string FirstName { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string lastName = string.Empty;
+        public partial string LastName { get; set; } = string.Empty;
 
         [ObservableProperty]
-        bool primary;
+        public partial bool Primary { get; set; }
 
         [ObservableProperty]
-        string emailAddress = string.Empty;
+        public partial string EmailAddress { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string phoneNumber = string.Empty;
+        public partial string PhoneNumber { get; set; } = string.Empty;
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Contact/LexContactsList.cs
+++ b/src/LexOfficeSharpApi/Model/Contact/LexContactsList.cs
@@ -7,31 +7,31 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        List<LexContact> content = [];
+        public partial List<LexContact> Content { get; set; } = [];
 
         [ObservableProperty]
-        bool first;
+        public partial bool First { get; set; }
 
         [ObservableProperty]
-        bool last;
+        public partial bool Last { get; set; }
 
         [ObservableProperty]
-        long totalPages;
+        public partial long TotalPages { get; set; }
 
         [ObservableProperty]
-        long totalElements;
+        public partial long TotalElements { get; set; }
 
         [ObservableProperty]
-        long numberOfElements;
+        public partial long NumberOfElements { get; set; }
 
         [ObservableProperty]
-        long size;
+        public partial long Size { get; set; }
 
         [ObservableProperty]
-        long number;
+        public partial long Number { get; set; }
 
         [ObservableProperty]
-        List<LexVoucherSort> sort = [];
+        public partial List<LexVoucherSort> Sort { get; set; } = [];
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Country/LexCountry.cs
+++ b/src/LexOfficeSharpApi/Model/Country/LexCountry.cs
@@ -8,16 +8,16 @@ namespace AndreasReitberger.API.LexOffice
         #region Properties
 
         [ObservableProperty]
-        string countryCode = string.Empty;
+        public partial string CountryCode { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string countryNameDE = string.Empty;
+        public partial string CountryNameDE { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string countryNameEN = string.Empty;
+        public partial string CountryNameEN { get; set; } = string.Empty;
 
         [ObservableProperty]
-        LexTaxClassifications taxClassification;
+        public partial LexTaxClassifications TaxClassification { get; set; }
         //string taxClassification = string.Empty;
         #endregion
     }

--- a/src/LexOfficeSharpApi/Model/Customer/LexCustomerNumber.cs
+++ b/src/LexOfficeSharpApi/Model/Customer/LexCustomerNumber.cs
@@ -6,7 +6,7 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        long number;
+        public partial long Number { get; set; }
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Invoice/LexCreateInvoice.cs
+++ b/src/LexOfficeSharpApi/Model/Invoice/LexCreateInvoice.cs
@@ -9,43 +9,43 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        bool archived;
+        public partial bool Archived { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset voucherDate;
+        public partial DateTimeOffset VoucherDate { get; set; }
 
         [ObservableProperty]
-        LexContactAddress? address;
+        public partial LexContactAddress? Address { get; set; }
 
         [ObservableProperty]
-        List<LexQuotationItem> lineItems = [];
+        public partial List<LexQuotationItem> LineItems { get; set; } = [];
 
         [ObservableProperty]
-        LexQuotationTotalPrice? totalPrice;
+        public partial LexQuotationTotalPrice? TotalPrice { get; set; }
 
         [ObservableProperty]
-        List<LexQuotationTaxAmount> taxAmounts = [];
+        public partial List<LexQuotationTaxAmount> TaxAmounts { get; set; } = [];
 
         [ObservableProperty]
-        LexQuotationTaxConditions? taxConditions;
+        public partial LexQuotationTaxConditions? TaxConditions { get; set; }
 
         [ObservableProperty]
-        LexQuotationPaymentConditions? paymentConditions;
+        public partial LexQuotationPaymentConditions? PaymentConditions { get; set; }
 
         [ObservableProperty]
-        LexShippingConditions? shippingConditions;
+        public partial LexShippingConditions? ShippingConditions { get; set; }
 
         [ObservableProperty]
-        string introduction = string.Empty;
+        public partial string Introduction { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string remark = string.Empty;
+        public partial string Remark { get; set; } = string.Empty;
 
         [ObservableProperty]
-        LexQuotationFiles? files;
+        public partial LexQuotationFiles? Files { get; set; }
 
         [ObservableProperty]
-        string title = string.Empty;
+        public partial string Title { get; set; } = string.Empty;
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Invoice/LexInvoiceResponse.cs
+++ b/src/LexOfficeSharpApi/Model/Invoice/LexInvoiceResponse.cs
@@ -8,19 +8,19 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        Guid id;
+        public partial Guid Id { get; set; }
 
         [ObservableProperty]
-        string resourceUri = string.Empty;
+        public partial string ResourceUri { get; set; } = string.Empty;
 
         [ObservableProperty]
-        DateTimeOffset createdDate;
+        public partial DateTimeOffset CreatedDate { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset updatedDate;
+        public partial DateTimeOffset UpdatedDate { get; set; }
 
         [ObservableProperty]
-        long version;
+        public partial long Version { get; set; }
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Invoice/LexShippingConditions.cs
+++ b/src/LexOfficeSharpApi/Model/Invoice/LexShippingConditions.cs
@@ -7,13 +7,13 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        DateTimeOffset shippingDate;
+        public partial DateTimeOffset ShippingDate { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset shippingEndDate;
+        public partial DateTimeOffset ShippingEndDate { get; set; }
 
         [ObservableProperty]
-        string shippingType = string.Empty;
+        public partial string ShippingType { get; set; } = string.Empty;
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Payment/LexPayment.cs
+++ b/src/LexOfficeSharpApi/Model/Payment/LexPayment.cs
@@ -7,16 +7,16 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        string paymentItemType = string.Empty;
+        public partial string PaymentItemType { get; set; } = string.Empty;
 
         [ObservableProperty]
-        DateTimeOffset postingDate;
+        public partial DateTimeOffset PostingDate { get; set; }
 
         [ObservableProperty]
-        decimal amount;
+        public partial decimal Amount { get; set; }
 
         [ObservableProperty]
-        string currency = string.Empty;
+        public partial string Currency { get; set; } = string.Empty;
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Payment/LexPayments.cs
+++ b/src/LexOfficeSharpApi/Model/Payment/LexPayments.cs
@@ -8,25 +8,25 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        decimal openAmount;
+        public partial decimal OpenAmount { get; set; }
 
         [ObservableProperty]
-        string paymentStatus = string.Empty;
+        public partial string PaymentStatus { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string currency = string.Empty;
+        public partial string Currency { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string voucherType = string.Empty;
+        public partial string VoucherType { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string voucherStatus = string.Empty;
+        public partial string VoucherStatus { get; set; } = string.Empty;
 
         [ObservableProperty]
-        DateTimeOffset paidDate;
+        public partial DateTimeOffset PaidDate { get; set; }
 
         [ObservableProperty]
-        List<LexPayment> paymentItems = [];
+        public partial List<LexPayment> PaymentItems { get; set; } = [];
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotation.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotation.cs
@@ -9,68 +9,69 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        Guid id;
+        public partial Guid Id { get; set; }
 
         [ObservableProperty]
-        Guid organizationId;
+        public partial Guid OrganizationId { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset createdDate;
+        public partial DateTimeOffset CreatedDate { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset updatedDate;
+        public partial DateTimeOffset UpdatedDate { get; set; }
 
         [ObservableProperty]
-        long version;
+        public partial long Version { get; set; }
 
         [ObservableProperty]
-        string language = string.Empty;
+        public partial string Language { get; set; } = string.Empty;
 
         [ObservableProperty]
-        bool archived;
+        public partial bool Archived { get; set; }
 
         [ObservableProperty]
-        string voucherStatus = string.Empty;
+        public partial string VoucherStatus { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string voucherNumber = string.Empty;
+        public partial string VoucherNumber { get; set; } = string.Empty;
 
         [ObservableProperty]
-        DateTimeOffset voucherDate;
+        public partial DateTimeOffset VoucherDate { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset expirationDate;
+        public partial DateTimeOffset ExpirationDate { get; set; }
 
         [ObservableProperty]
-        LexContactAddress? address;
+        public partial LexContactAddress? Address { get; set; }
 
         [ObservableProperty]
-        List<LexQuotationItem> lineItems = [];
+        public partial List<LexQuotationItem> LineItems { get; set; } = [];
 
         [ObservableProperty]
-        LexQuotationTotalPrice? totalPrice;
+        public partial LexQuotationTotalPrice? TotalPrice { get; set; }
 
         [ObservableProperty]
-        List<LexQuotationTaxAmount> taxAmounts = [];
+        public partial List<LexQuotationTaxAmount> TaxAmounts { get; set; } = [];
 
         [ObservableProperty]
-        LexQuotationTaxConditions? taxConditions;
+        public partial LexQuotationTaxConditions? TaxConditions { get; set; }
+
         //Dictionary<string, string> taxConditions;
 
         [ObservableProperty]
-        LexQuotationPaymentConditions? paymentConditions;
+        public partial LexQuotationPaymentConditions? PaymentConditions { get; set; }
 
         [ObservableProperty]
-        string introduction = string.Empty;
+        public partial string Introduction { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string remark = string.Empty;
+        public partial string Remark { get; set; } = string.Empty;
 
         [ObservableProperty]
-        LexQuotationFiles? files;
+        public partial LexQuotationFiles? Files { get; set; }
 
         [ObservableProperty]
-        string title = string.Empty;
+        public partial string Title { get; set; } = string.Empty;
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationDiscountCondition.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationDiscountCondition.cs
@@ -6,10 +6,10 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        decimal discountPercentage;
+        public partial decimal DiscountPercentage { get; set; }
 
         [ObservableProperty]
-        long discountRange;
+        public partial long DiscountRange { get; set; }
 
         #endregion
     }

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationFiles.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationFiles.cs
@@ -8,7 +8,7 @@ namespace AndreasReitberger.API.LexOffice
         #region Properties
 
         [ObservableProperty]
-        Guid documentFileId;
+        public partial Guid DocumentFileId { get; set; }
 
         #endregion
     }

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationItem.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationItem.cs
@@ -9,42 +9,42 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
+        [field: JsonIgnore]
         [JsonIgnore]
-        [property: JsonIgnore]
-        Guid? id;
+        public partial Guid? Id { get; set; }
 
         [ObservableProperty]
-        string type = string.Empty;
+        public partial string Type { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string name = string.Empty;
+        public partial string Name { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string description = string.Empty;
+        public partial string Description { get; set; } = string.Empty;
 
         [ObservableProperty]
-        decimal quantity;
+        public partial decimal Quantity { get; set; }
 
         [ObservableProperty]
-        string unitName = string.Empty;
+        public partial string UnitName { get; set; } = string.Empty;
 
         [ObservableProperty]
-        LexQuotationUnitPrice? unitPrice;
+        public partial LexQuotationUnitPrice? UnitPrice { get; set; }
 
         [ObservableProperty]
-        long discountPercentage;
+        public partial long DiscountPercentage { get; set; }
 
         [ObservableProperty]
-        double lineItemAmount;
+        public partial double LineItemAmount { get; set; }
 
         [ObservableProperty]
-        List<LexQuotationItem> subItems = [];
+        public partial List<LexQuotationItem> SubItems { get; set; } = [];
 
         [ObservableProperty]
-        bool alternative;
+        public partial bool Alternative { get; set; }
 
         [ObservableProperty]
-        bool optional;
+        public partial bool Optional { get; set; }
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationPaymentConditions.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationPaymentConditions.cs
@@ -8,22 +8,22 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        Guid? id;
+        public partial Guid? Id { get; set; }
 
         [ObservableProperty]
-        string paymentTermLabel = string.Empty;
+        public partial string PaymentTermLabel { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string paymentTermLabelTemplate = string.Empty;
+        public partial string PaymentTermLabelTemplate { get; set; } = string.Empty;
 
         [ObservableProperty]
-        long paymentTermDuration;
+        public partial long PaymentTermDuration { get; set; }
 
         [ObservableProperty]
-        LexQuotationDiscountCondition? paymentDiscountConditions;
+        public partial LexQuotationDiscountCondition? PaymentDiscountConditions { get; set; }
 
         [ObservableProperty]
-        bool organizationDefault;
+        public partial bool OrganizationDefault { get; set; }
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationTaxAmount.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationTaxAmount.cs
@@ -6,13 +6,13 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        long taxRatePercentage;
+        public partial long TaxRatePercentage { get; set; }
 
         [ObservableProperty]
-        decimal taxAmount;
+        public partial decimal TaxAmount { get; set; }
 
         [ObservableProperty]
-        decimal netAmount;
+        public partial decimal NetAmount { get; set; }
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationTaxConditions.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationTaxConditions.cs
@@ -10,7 +10,7 @@ namespace AndreasReitberger.API.LexOffice
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(TaxTypeString))]
-        LexQuotationTaxType taxType;
+        public partial LexQuotationTaxType TaxType { get; set; }
 
         [JsonIgnore]
         public string TaxTypeString => $"{TaxType}";

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationTotalPrice.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationTotalPrice.cs
@@ -6,16 +6,16 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        string currency = string.Empty;
+        public partial string Currency { get; set; } = string.Empty;
 
         [ObservableProperty]
-        decimal totalNetAmount;
+        public partial decimal TotalNetAmount { get; set; }
 
         [ObservableProperty]
-        decimal totalGrossAmount;
+        public partial decimal TotalGrossAmount { get; set; }
 
         [ObservableProperty]
-        decimal totalTaxAmount;
+        public partial decimal TotalTaxAmount { get; set; }
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Quotation/LexQuotationUnitPrice.cs
+++ b/src/LexOfficeSharpApi/Model/Quotation/LexQuotationUnitPrice.cs
@@ -6,16 +6,16 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        string currency = string.Empty;
+        public partial string Currency { get; set; } = string.Empty;
 
         [ObservableProperty]
-        decimal netAmount;
+        public partial decimal NetAmount { get; set; }
 
         [ObservableProperty]
-        decimal grossAmount;
+        public partial decimal GrossAmount { get; set; }
 
         [ObservableProperty]
-        long taxRatePercentage;
+        public partial long TaxRatePercentage { get; set; }
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Response/LexDocumentResponse.cs
+++ b/src/LexOfficeSharpApi/Model/Response/LexDocumentResponse.cs
@@ -8,70 +8,70 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        Guid id;
+        public partial Guid Id { get; set; }
 
         [ObservableProperty]
-        Guid organizationId;
+        public partial Guid OrganizationId { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset createdDate;
+        public partial DateTimeOffset CreatedDate { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset updatedDate;
+        public partial DateTimeOffset UpdatedDate { get; set; }
 
         [ObservableProperty]
-        long version;
+        public partial long Version { get; set; }
 
         [ObservableProperty]
-        string language = string.Empty;
+        public partial string Language { get; set; } = string.Empty;
 
         [ObservableProperty]
-        bool archived;
+        public partial bool Archived { get; set; }
 
         [ObservableProperty]
-        string voucherStatus = string.Empty;
+        public partial string VoucherStatus { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string voucherNumber = string.Empty;
+        public partial string VoucherNumber { get; set; } = string.Empty;
 
         [ObservableProperty]
-        DateTimeOffset voucherDate;
+        public partial DateTimeOffset VoucherDate { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset expirationDate;
+        public partial DateTimeOffset ExpirationDate { get; set; }
 
         [ObservableProperty]
-        LexContactAddress? address;
+        public partial LexContactAddress? Address { get; set; }
 
         [ObservableProperty]
-        List<LexQuotationItem> lineItems = [];
+        public partial List<LexQuotationItem> LineItems { get; set; } = [];
 
         [ObservableProperty]
-        LexQuotationTotalPrice? totalPrice;
+        public partial LexQuotationTotalPrice? TotalPrice { get; set; }
 
         [ObservableProperty]
-        List<LexQuotationTaxAmount> taxAmounts = [];
+        public partial List<LexQuotationTaxAmount> TaxAmounts { get; set; } = [];
 
         [ObservableProperty]
-        LexQuotationTaxConditions? taxConditions;
+        public partial LexQuotationTaxConditions? TaxConditions { get; set; }
 
         [ObservableProperty]
-        LexQuotationPaymentConditions? paymentConditions;
+        public partial LexQuotationPaymentConditions? PaymentConditions { get; set; }
 
         [ObservableProperty]
-        LexShippingConditions? shippingConditions;
+        public partial LexShippingConditions? ShippingConditions { get; set; }
 
         [ObservableProperty]
-        string introduction = string.Empty;
+        public partial string Introduction { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string remark = string.Empty;
+        public partial string Remark { get; set; } = string.Empty;
 
         [ObservableProperty]
-        LexQuotationFiles? files;
+        public partial LexQuotationFiles? Files { get; set; }
 
         [ObservableProperty]
-        string title = string.Empty;
+        public partial string Title { get; set; } = string.Empty;
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Response/LexResponseDefault.cs
+++ b/src/LexOfficeSharpApi/Model/Response/LexResponseDefault.cs
@@ -6,36 +6,36 @@ namespace AndreasReitberger.API.LexOffice
     public partial class LexResponseDefault : ObservableObject
     {
         [ObservableProperty]
-        Guid? id;
+        public partial Guid? Id { get; set; }
 
         [ObservableProperty]
-        Guid subscriptionId;
+        public partial Guid SubscriptionId { get; set; }
 
         [ObservableProperty]
-        Guid organizationId;
+        public partial Guid OrganizationId { get; set; }
 
         [ObservableProperty]
-        Guid resourceId;
+        public partial Guid ResourceId { get; set; }
 
         [ObservableProperty]
-        Uri? resourceUri;
+        public partial Uri? ResourceUri { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset createdDate;
+        public partial DateTimeOffset CreatedDate { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset updatedDate;
+        public partial DateTimeOffset UpdatedDate { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset eventDate;
+        public partial DateTimeOffset EventDate { get; set; }
 
         [ObservableProperty]
-        string eventType = string.Empty;
+        public partial string EventType { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string callbackUrl = string.Empty;
+        public partial string CallbackUrl { get; set; } = string.Empty;
 
         [ObservableProperty]
-        long version;
+        public partial long Version { get; set; }
     }
 }

--- a/src/LexOfficeSharpApi/Model/Voucher/LexVoucherList.cs
+++ b/src/LexOfficeSharpApi/Model/Voucher/LexVoucherList.cs
@@ -7,31 +7,31 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        List<VoucherListContent> content = [];
+        public partial List<VoucherListContent> Content { get; set; } = [];
 
         [ObservableProperty]
-        bool first;
+        public partial bool First { get; set; }
 
         [ObservableProperty]
-        bool last;
+        public partial bool Last { get; set; }
 
         [ObservableProperty]
-        long totalPages;
+        public partial long TotalPages { get; set; }
 
         [ObservableProperty]
-        long totalElements;
+        public partial long TotalElements { get; set; }
 
         [ObservableProperty]
-        long numberOfElements;
+        public partial long NumberOfElements { get; set; }
 
         [ObservableProperty]
-        long size;
+        public partial long Size { get; set; }
 
         [ObservableProperty]
-        long number;
+        public partial long Number { get; set; }
 
         [ObservableProperty]
-        List<LexVoucherSort> sort = [];
+        public partial List<LexVoucherSort> Sort { get; set; } = [];
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Voucher/LexVoucherSort.cs
+++ b/src/LexOfficeSharpApi/Model/Voucher/LexVoucherSort.cs
@@ -6,19 +6,19 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        string property = string.Empty;
+        public partial string Property { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string direction = string.Empty;
+        public partial string Direction { get; set; } = string.Empty;
 
         [ObservableProperty]
-        bool? ignoreCase;
+        public partial bool? IgnoreCase { get; set; }
 
         [ObservableProperty]
-        string nullHandling = string.Empty;
+        public partial string NullHandling { get; set; } = string.Empty;
 
         [ObservableProperty]
-        bool? ascending;
+        public partial bool? Ascending { get; set; }
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Model/Voucher/VoucherListContent.cs
+++ b/src/LexOfficeSharpApi/Model/Voucher/VoucherListContent.cs
@@ -8,37 +8,37 @@ namespace AndreasReitberger.API.LexOffice
     {
         #region Properties
         [ObservableProperty]
-        Guid id;
+        public partial Guid Id { get; set; }
 
         [ObservableProperty]
-        string voucherType = string.Empty;
+        public partial string VoucherType { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string voucherStatus = string.Empty;
+        public partial string VoucherStatus { get; set; } = string.Empty;
 
         [ObservableProperty]
-        string voucherNumber = string.Empty;
+        public partial string VoucherNumber { get; set; } = string.Empty;
 
         [ObservableProperty]
-        DateTimeOffset voucherDate;
+        public partial DateTimeOffset VoucherDate { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset updatedDate;
+        public partial DateTimeOffset UpdatedDate { get; set; }
 
         [ObservableProperty]
-        DateTimeOffset dueDate;
+        public partial DateTimeOffset DueDate { get; set; }
 
         [ObservableProperty]
-        string contactName = string.Empty;
+        public partial string ContactName { get; set; } = string.Empty;
 
         [ObservableProperty]
-        decimal totalAmount;
+        public partial decimal TotalAmount { get; set; }
 
         [ObservableProperty]
-        string currency = string.Empty;
+        public partial string Currency { get; set; } = string.Empty;
 
         [ObservableProperty]
-        bool archived;
+        public partial bool Archived { get; set; }
         #endregion
     }
 }

--- a/src/LexOfficeSharpApi/Struct/AcceptedFileHeaders.cs
+++ b/src/LexOfficeSharpApi/Struct/AcceptedFileHeaders.cs
@@ -1,0 +1,11 @@
+﻿namespace AndreasReitberger.API.LexOffice.Struct
+{
+    public struct AcceptedFileHeaders
+    {
+        public const string Xml = "application/xml";
+        public const string Jpeg = "application/jpeg";
+        public const string Png = "application/png";
+        public const string Pdf = "application/pdf";
+        public const string All = "*/*";
+    }
+}


### PR DESCRIPTION
This PR migrates the project to inherit from the `RestApiClient` class from our new `REST` basement project.

- [x] Migrate to use `RestApiClient`
- [x] Switch from `BaseApiCallAsync` to `SendRestApiRequestAsync` => Example `GetContactNewAsync()`
- [x] Run `Tests` to verify function of the migration

Fixed #47